### PR TITLE
Audio

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,9 @@ PKG_CONFIG ?= pkg-config
 SD_BUS_LIB := $(shell if   $(PKG_CONFIG) --exists basu       2>/dev/null; then echo "basu"; \
 			          elif $(PKG_CONFIG) --exists libsystemd 2>/dev/null; then echo "libsystemd"; \
 					  fi)
-ffmpeg_libs := libavcodec libavutil libavformat libavfilter
-PKGCONF_LIBS := xkbcommon wayland-client $(ffmpeg_libs) $(SD_BUS_LIB)
+ffmpeg_libs   := libavcodec libavutil libavformat libavfilter
+pipewire_libs := libpipewire-0.3 libspa-0.2
+PKGCONF_LIBS  := xkbcommon wayland-client $(pipewire_libs) $(ffmpeg_libs) $(SD_BUS_LIB)
 
 _LDLIBS := -lblend2d -lm
 _LDLIBS += $(shell $(PKG_CONFIG) --libs $(PKGCONF_LIBS))

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -11,6 +11,7 @@ depends=(
     'libxkbcommon'
     'libsystemd'
     'ffmpeg'
+    'libpipewire'
     'blend2d'
 )
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ in
    <details open> <summary><ins>Arch</ins></summary>
 
    ```bash
-   pacman -S   base-devel wayland wayland-protocols libxkbcommon libsystemd ffmpeg
+   pacman -S   base-devel wayland wayland-protocols libxkbcommon libsystemd libpipewire ffmpeg
    # Install Blend2D through the AUR (See below if you prefer to build Blend2D manually.)
    yay -S blend2d
    ```
@@ -134,7 +134,7 @@ in
    <details> <summary><ins>Ubuntu</ins></summary>
 
    ```bash
-   apt install make gcc pkg-config libwayland-dev wayland-protocols libxkbcommon-dev libsystemd libavcodec-dev libavutil-dev libavformat-dev libavfilter-dev
+   apt install make gcc pkg-config libwayland-dev wayland-protocols libxkbcommon-dev libsystemd libpipewire-0.3-dev libavcodec-dev libavutil-dev libavformat-dev libavfilter-dev
    ```
    </details>
    <details> <summary><ins>Fedora</ins></summary>
@@ -146,7 +146,7 @@ in
             Your mileage may vary.
 
    ```bash
-   dnf install make gcc pkg-config wayland-devel wayland-protocols-devel libxkbcommon-devel systemd-devel libavcodec-free-devel libavutil-free-devel libavformat-free-devel libavfilter-free-devel blend2d-devel
+   dnf install make gcc pkg-config wayland-devel wayland-protocols-devel libxkbcommon-devel systemd-devel pipewire-devel libavcodec-free-devel libavutil-free-devel libavformat-free-devel libavfilter-free-devel blend2d-devel
    ```
    </details>
 
@@ -307,6 +307,7 @@ See `scran -h` for more details
          You may also use $SCRAN_OUTPUT_DIR.
   -p   press-only mouse buttons (presses toggle pressed/released state)
   -e   automatically capture and exit immediately after initial selection
+  -A   disable audio capture (during video capture)
   -B   do not keep background process alive
   -s   slurp: send selection as geometry string to standard output
          Equivalent to slurp's default output.
@@ -322,7 +323,6 @@ Send SIGUSR1 to the running scran to start grabbing inputs again after releasing
 - Example: `pkill -SIGUSR1 scran`
 
 ## TODOs (*not comprehensive*)
-- Audio capture
 - GPU-accelerated video capture
   - planned for after the CPU pipeline is more optimized (primarily improving performance for rotated displays).
 - More configuration

--- a/default.nix
+++ b/default.nix
@@ -8,6 +8,7 @@
   blend2d,
   libxkbcommon,
   ffmpeg,
+  pipewire,
   basu, # libsystemd's sd-bus library
   copyDesktopItems,
   makeDesktopItem,
@@ -37,6 +38,7 @@ stdenv.mkDerivation {
     blend2d
     libxkbcommon
     ffmpeg
+    pipewire
     basu
   ];
 

--- a/include/capture.h
+++ b/include/capture.h
@@ -13,7 +13,7 @@
 #define BITS_PER_MEGABIT 1000000
 
 #define AV_FORMAT_STREAM_IDX_VIDEO 0
-// #define AV_FORMAT_STREAM_IDX_AUDIO 1
+#define AV_FORMAT_STREAM_IDX_AUDIO 1
 
 #define CAPTURE_IMAGE_OUTPUT_BLFORMAT_DEFAULT BL_FORMAT_PRGB32
 #define CAPTURE_IMAGE_OUTPUT_BLIMAGECODEC_NAME_DEFAULT "PNG"
@@ -24,6 +24,7 @@ uint8_t *get_capture_area_start_address(struct capture_frame_context *frame_ctx)
 void update_capture_area_with_selection(struct scran_output *st_output, BLBoxI selection_box);
 
 void write_video_frame(struct capture_frame_context *frame_ctx, AVPacket *pkt);
+void write_audio_packet(struct capture_frame_context *frame_ctx, AVPacket *av_packet);
 bool request_video_capture(struct scran_output *st_output);
  void end_video_capture(struct scran_output *st_output);
 void request_video_capture_frame(struct capture_frame_context *frame_ctx, int32_t damage_x, int32_t damage_y, int32_t damage_w, int32_t damage_h);

--- a/include/capture.h
+++ b/include/capture.h
@@ -23,6 +23,7 @@
 uint8_t *get_capture_area_start_address(struct capture_frame_context *frame_ctx);
 void update_capture_area_with_selection(struct scran_output *st_output, BLBoxI selection_box);
 
+void write_video_frame(struct capture_frame_context *frame_ctx, AVPacket *pkt);
 bool request_video_capture(struct scran_output *st_output);
  void end_video_capture(struct scran_output *st_output);
 void request_video_capture_frame(struct capture_frame_context *frame_ctx, int32_t damage_x, int32_t damage_y, int32_t damage_w, int32_t damage_h);

--- a/include/pipewires.h
+++ b/include/pipewires.h
@@ -1,0 +1,25 @@
+#ifndef SCRAN_PIPEWIRES_H
+#define SCRAN_PIPEWIRES_H
+
+
+#include <pipewire/pipewire.h>
+#include <spa/param/format-types.h>
+
+#include "state.h"
+
+
+// TODO: Use struct spa_audio_info_raw to set this dynamically or to
+// let e.g. init_ffmpeg() decide.
+#define SCRAN_PIPEWIRE_N_CHANNELS 2
+#define SCRAN_PIPEWIRE_SAMPLE_RATE 48000
+
+
+void scran_pipewire_pre_init(int epoll_fd);
+ bool scran_pipewire_init(struct capture_frame_context *frame_ctx, enum spa_audio_format format);
+ void scran_pipewire_reset();
+ void scran_pipewire_destroy();
+bool scran_pipewire_update( int fd_ready);
+bool scran_pipewire_connect();
+
+
+#endif

--- a/include/state.h
+++ b/include/state.h
@@ -274,7 +274,7 @@ struct capture_frame_context {
     BLImageCodecCore bl_imgcodec;
 
     uint64_t presentation_time_nsec_start;
-    uint64_t presentation_time_nsec;
+    int64_t presentation_time_nsec;
 
     //  NOTE: Capture area should be set synchronously with the drawn overlay's
     //        area (or be set based on the same real-time values). Otherwise,

--- a/include/state.h
+++ b/include/state.h
@@ -13,6 +13,7 @@
 #include <libavcodec/avcodec.h>
 #include <libavformat/avformat.h>
 #include <libavfilter/avfilter.h>
+#include <libavutil/audio_fifo.h>
 
 #include "wlr-layer-shell-unstable-v1.h"
 #include "ext-image-capture-source-v1.h"
@@ -269,11 +270,18 @@ struct capture_frame_context {
     // graph's refcouning?
     AVFilterContext *av_filter_transpose_ctx;
     AVFilterContext *av_filter_buffersink_ctx;
+    //
+    // Audio
+    //
+    AVCodecContext  *av_codec_ctx_audio;
+    AVFrame         *av_frame_captured_audio;
+    AVPacket        *av_packet_audio;
+    AVAudioFifo     *av_audio_fifo;
 
     BLImageCore bl_img_captured;
     BLImageCodecCore bl_imgcodec;
 
-    uint64_t presentation_time_nsec_start;
+    int64_t presentation_time_nsec_start;
     int64_t presentation_time_nsec;
 
     //  NOTE: Capture area should be set synchronously with the drawn overlay's
@@ -294,10 +302,8 @@ struct capture_frame_context {
     int32_t source_height_px;
     uint8_t pixel_stride;
 
-    // TODO: Probably turn this into a union with some member that gets
-    //       re-initialized with every start/stop capture.
-    //         - Union with presentation_time ?
     bool capturing_video;
+    bool audio_active;
 };
 
 struct scran_output_capture {
@@ -359,6 +365,7 @@ struct scran_options {
 
     bool output_to_stdout;
     bool no_keepalive;
+    bool disable_audio_capture;
     bool capture_and_exit_after_selection_init;
     bool produce_slurp;                 // output slurp-style geometry string
     bool no_notifications;

--- a/include/state.h
+++ b/include/state.h
@@ -273,6 +273,7 @@ struct capture_frame_context {
     BLImageCore bl_img_captured;
     BLImageCodecCore bl_imgcodec;
 
+    uint64_t presentation_time_nsec_start;
     uint64_t presentation_time_nsec;
 
     //  NOTE: Capture area should be set synchronously with the drawn overlay's

--- a/include/state.h
+++ b/include/state.h
@@ -254,12 +254,15 @@ struct capture_frame_context {
 
     struct ext_image_copy_capture_session_v1 *wl_capture_session;
 
+    //
+    // Video
+    //
     AVFormatContext *av_format_ctx;
-    AVCodecContext *av_codec_ctx;
-    AVFrame *av_frame_captured;
-    AVFrame *av_frame_to_encode;
-    AVPacket *av_packet; // encoded frame
-    AVFilterGraph *av_filter_graph;
+    AVCodecContext  *av_codec_ctx;
+    AVFrame         *av_frame_captured;
+    AVFrame         *av_frame_to_encode;
+    AVPacket        *av_packet; // encoded frame
+    AVFilterGraph   *av_filter_graph;
     AVFilterContext *av_filter_buffersrc_ctx;
     // TODO: Do we need to keep non-endpoint filters (like transpose) around
     // for freeing them, or are they automatically freed through the parent

--- a/include/util/lib-interop.h
+++ b/include/util/lib-interop.h
@@ -4,6 +4,7 @@
 #include <wayland-client.h>
 #include <blend2d/blend2d.h>
 #include <libavcodec/avcodec.h>
+#include "spa/param/audio/raw.h"
 
 #define RGBA32_SHUFFLE_ERROR ((uint32_t)0x00000000)
 #define RGBA32_SHUFFLE_NO_CHANGE ((uint32_t)0x03020100)
@@ -37,5 +38,7 @@ enum AVPixelFormat wl_shm_format_to_ffmpeg(enum wl_shm_format wl_shm_format);
 const char * wl_shm_format_to_ffmpeg_cli_str(enum wl_shm_format wl_shm_format);
 
 enum ScranAVTransposeDir wl_output_transform_to_ffmpeg_transpose_dir__inverse(enum wl_output_transform transform);
+
+enum spa_audio_format ffmpeg_sample_format_to_pipewire(enum AVSampleFormat format);
 
 #endif

--- a/src/capture.c
+++ b/src/capture.c
@@ -36,6 +36,34 @@
 extern struct scran g_state;
 
 
+void
+write_video_frame(
+    struct capture_frame_context *frame_ctx,
+    AVPacket *pkt // Encoded frame
+) {
+    assert(pkt != NULL);
+
+    const AVStream *const _av_stream = frame_ctx->av_format_ctx->streams[AV_FORMAT_STREAM_IDX_VIDEO];
+
+    pkt->stream_index = AV_FORMAT_STREAM_IDX_VIDEO;
+    assert(pkt->stream_index == _av_stream->index);
+
+    // NOTE: This is doing the work of av_packet_rescale_ts(), but with
+    // asserts instead of conditionals. Just switch to that or to
+    // if-statements if indeterminism becomes necessary.
+    assert(pkt->pts != AV_NOPTS_VALUE);
+    pkt->pts = av_rescale_q(pkt->pts, frame_ctx->av_codec_ctx->time_base, _av_stream->time_base);
+    assert(pkt->dts != AV_NOPTS_VALUE);
+    pkt->dts = av_rescale_q(pkt->dts, frame_ctx->av_codec_ctx->time_base, _av_stream->time_base);
+
+    // We don't use durations for VFR.
+    //     XXX: This gives a warning on the last frame before
+    //     avformat_write_header(). Not sure if worth fixing.
+    assert(pkt->duration <= 0);
+
+    av_interleaved_write_frame(frame_ctx->av_format_ctx, pkt);
+}
+
 uint8_t *
 get_capture_area_start_address(
     struct capture_frame_context *frame_ctx
@@ -440,16 +468,12 @@ end_video_capture(struct scran_output *st_output)
 {
     struct capture_frame_context *frame_ctx = &st_output->capture.frame_ctx;
 
-#ifndef NDEBUG
-    // All actual capture/encoding-related logic, including draining the codec
-    // before end of capture, is done in the capture_frame::ready event loop.
-    {
-        AVPacket *pkt = av_packet_alloc();
-        int ret = avcodec_receive_packet(frame_ctx->av_codec_ctx, pkt);
-        av_packet_free(&pkt);
-        assert(ret == AVERROR_EOF && "Encoder was not fully drained before end_video_capture()");
+    // Drain codec
+    avcodec_send_frame(frame_ctx->av_codec_ctx, NULL);
+    assert(frame_ctx->av_packet != NULL);
+    while (avcodec_receive_packet(frame_ctx->av_codec_ctx, frame_ctx->av_packet) != AVERROR_EOF) {
+        write_video_frame(frame_ctx, frame_ctx->av_packet);
     }
-#endif/*NDEBUG*/
 
     av_write_trailer(frame_ctx->av_format_ctx);
     eprintf("Video saved: %s\n", g_state.options.output_path);

--- a/src/capture.c
+++ b/src/capture.c
@@ -124,10 +124,10 @@ init_ffmpeg(struct scran_output *st_output)
 
 
     // AVFrame (captured)
-    frame_ctx->av_frame_captured = av_frame_alloc();
-    frame_ctx->av_frame_captured->width = width_px_captured;
-    frame_ctx->av_frame_captured->height = height_px_captured;
-    frame_ctx->av_frame_captured->format = av_pixel_format_captured;
+    frame_ctx->av_frame_captured              = av_frame_alloc();
+    frame_ctx->av_frame_captured->width       = width_px_captured;
+    frame_ctx->av_frame_captured->height      = height_px_captured;
+    frame_ctx->av_frame_captured->format      = av_pixel_format_captured;
     // XXX: We won't ever get planar src frame buffers, right..?
     frame_ctx->av_frame_captured->linesize[0] = get_capture_stride(st_output);
     assert(frame_ctx->av_frame_captured->linesize[0] == frame_ctx->pixel_stride * frame_ctx->source_width_px);
@@ -204,8 +204,8 @@ init_ffmpeg(struct scran_output *st_output)
 
 
     // AVFrame (converted, ready to be fed to encoder)
-    frame_ctx->av_frame_to_encode = av_frame_alloc();
-    frame_ctx->av_frame_to_encode->width = width_px_to_encode;
+    frame_ctx->av_frame_to_encode         = av_frame_alloc();
+    frame_ctx->av_frame_to_encode->width  = width_px_to_encode;
     frame_ctx->av_frame_to_encode->height = height_px_to_encode;
     frame_ctx->av_frame_to_encode->format = av_pixel_format_to_encode;
 

--- a/src/capture.c
+++ b/src/capture.c
@@ -366,21 +366,14 @@ destroy_ffmpeg(struct scran_output *st_output)
 
     // Note: Most (all?) of these are fine to call with null pointers, despite
     // the asserts
-    assert(frame_ctx->av_format_ctx->pb);
     avio_close(frame_ctx->av_format_ctx->pb);
-    assert(frame_ctx->av_packet);
     av_packet_free(&frame_ctx->av_packet);
-    assert(frame_ctx->av_codec_ctx);
     avcodec_free_context(&frame_ctx->av_codec_ctx);
-    assert(frame_ctx->av_format_ctx);
     // Freeing the format context frees the linked stream for us.
     avformat_free_context(frame_ctx->av_format_ctx);
-    assert(frame_ctx->av_frame_to_encode);
     av_frame_free(&frame_ctx->av_frame_to_encode);
-    assert(frame_ctx->av_filter_graph);
     // Freeing the graph frees any linked filter contexts for us.
     avfilter_graph_free(&frame_ctx->av_filter_graph);
-    assert(frame_ctx->av_frame_captured);
     av_frame_free(&frame_ctx->av_frame_captured);
 }
 

--- a/src/capture.c
+++ b/src/capture.c
@@ -415,6 +415,13 @@ request_video_capture(struct scran_output *st_output)
 
     set_selection_surface_theme(st_output, SURFACE_THEME_VIDEO_CAPTURE);
 
+    // image-copy-capture protocol guarantees we get presentation time based
+    // on system monotonic time.
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    // XXX: Will overflow at tv_sec > ~584.9 years...
+    st_output->capture.frame_ctx.presentation_time_nsec_start = ts.tv_sec * NSEC_PER_SEC + ts.tv_nsec;
+
     // Get initial frame. Subsequent capture requests happen within
     // frame::ready, similar to the wl_surface callback event loop
     request_video_capture_frame(

--- a/src/capture.c
+++ b/src/capture.c
@@ -24,6 +24,7 @@
 #include "options.h"
 #include "clipboard.h"
 #include "portals.h"
+#include "pipewires.h"
 
 
 #define _FORMAT_MP4_FILE_EXTENSION ".mp4"
@@ -35,6 +36,30 @@
 
 extern struct scran g_state;
 
+
+void
+write_audio_packet(
+    struct capture_frame_context *frame_ctx,
+    AVPacket *pkt // Encoded frame
+) {
+    assert(pkt != NULL);
+
+    const AVStream *const av_stream = frame_ctx->av_format_ctx->streams[AV_FORMAT_STREAM_IDX_AUDIO];
+    pkt->stream_index = AV_FORMAT_STREAM_IDX_AUDIO;
+    assert(pkt->stream_index == av_stream->index);
+
+    // NOTE: This is doing the work of av_packet_rescale_ts(), but with
+    // asserts instead of conditionals. Just switch to that or to
+    // if-statements if indeterminism becomes necessary.
+    assert(pkt->pts != AV_NOPTS_VALUE);
+    pkt->pts = av_rescale_q(pkt->pts, frame_ctx->av_codec_ctx_audio->time_base, av_stream->time_base);
+    assert(pkt->dts != AV_NOPTS_VALUE);
+    pkt->dts = av_rescale_q(pkt->dts, frame_ctx->av_codec_ctx_audio->time_base, av_stream->time_base);
+    assert(pkt->duration != AV_NOPTS_VALUE);
+    pkt->duration = av_rescale_q(pkt->duration, frame_ctx->av_codec_ctx_audio->time_base, av_stream->time_base);
+
+    av_interleaved_write_frame(frame_ctx->av_format_ctx, pkt);
+}
 
 void
 write_video_frame(
@@ -117,6 +142,77 @@ request_video_capture_frame(
     );
 }
 
+
+static inline bool
+destroy_ffmpeg_audio(struct scran_output *st_output)
+{
+    struct capture_frame_context *frame_ctx = &st_output->capture.frame_ctx;
+
+    avcodec_free_context(&frame_ctx->av_codec_ctx_audio);
+    av_frame_free(&frame_ctx->av_frame_captured_audio);
+    av_audio_fifo_free(frame_ctx->av_audio_fifo);
+    av_packet_free(&frame_ctx->av_packet_audio);
+
+    return true;
+}
+
+static inline bool
+init_ffmpeg_audio(struct scran_output *st_output)
+{
+    struct capture_frame_context *frame_ctx = &st_output->capture.frame_ctx;
+
+    // Float planar should be guaranteed supported for pipewire(?)
+    // TODO: Retrieve the sample_fmt using avcodec_get_supported_config() if we
+    // implement user-provided settings. FLTP/F32P is supported for AAC.
+    static const enum AVSampleFormat sample_fmt     = AV_SAMPLE_FMT_FLTP;
+    static const enum AVCodecID      codec_id       = AV_CODEC_ID_AAC;
+    static const AVChannelLayout     channel_layout = AV_CHANNEL_LAYOUT_STEREO;
+    static const int                 sample_rate    = SCRAN_PIPEWIRE_SAMPLE_RATE;
+    static const AVRational          time_base      = { 1, NSEC_PER_SEC };
+
+    assert(channel_layout.nb_channels == SCRAN_PIPEWIRE_N_CHANNELS);
+
+    scran_pipewire_init(frame_ctx, ffmpeg_sample_format_to_pipewire(sample_fmt));
+
+    // AVFrame (captured)
+    frame_ctx->av_frame_captured_audio              = av_frame_alloc();
+    frame_ctx->av_frame_captured_audio->format      = sample_fmt;
+    frame_ctx->av_frame_captured_audio->sample_rate = sample_rate;
+    frame_ctx->av_frame_captured_audio->ch_layout   = channel_layout;
+
+    // AVCodec
+    const AVCodec *codec = avcodec_find_encoder(codec_id);
+
+    // AVCodecContext
+    frame_ctx->av_codec_ctx_audio              = avcodec_alloc_context3(codec);
+    if (frame_ctx->av_format_ctx->oformat->flags & AVFMT_GLOBALHEADER) {
+        frame_ctx->av_codec_ctx_audio->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
+    }
+    frame_ctx->av_codec_ctx_audio->sample_rate = sample_rate;
+    frame_ctx->av_codec_ctx_audio->sample_fmt  = sample_fmt;
+    frame_ctx->av_codec_ctx_audio->time_base   = time_base;
+    frame_ctx->av_codec_ctx_audio->ch_layout   = channel_layout;
+    avcodec_open2(frame_ctx->av_codec_ctx_audio, codec, NULL);
+
+    // AVFrame (captured, cont.)
+    frame_ctx->av_frame_captured_audio->nb_samples  = frame_ctx->av_codec_ctx_audio->frame_size;
+    av_frame_get_buffer(frame_ctx->av_frame_captured_audio, 0);
+
+    // AVAudioFifo
+    frame_ctx->av_audio_fifo = av_audio_fifo_alloc(
+        sample_fmt, channel_layout.nb_channels, frame_ctx->av_codec_ctx_audio->frame_size
+    );
+
+    // AVPacket (encoded)
+    frame_ctx->av_packet_audio = av_packet_alloc();
+
+    // AVStream
+    AVStream *audio_stream = avformat_new_stream(frame_ctx->av_format_ctx, codec);
+    assert(audio_stream == frame_ctx->av_format_ctx->streams[AV_FORMAT_STREAM_IDX_AUDIO]);
+    avcodec_parameters_from_context(audio_stream->codecpar, frame_ctx->av_codec_ctx_audio);
+
+    return true;
+}
 
 // TODO:
 //  - Error checking
@@ -343,6 +439,17 @@ init_ffmpeg(struct scran_output *st_output)
     }
 
 
+    if (!g_state.options.disable_audio_capture) {
+        if (init_ffmpeg_audio(st_output)) {
+            frame_ctx->audio_active = true;
+        } else {
+            eprintf("Warning: Failed to init audio capture.\n");
+            scran_pipewire_reset();
+            destroy_ffmpeg_audio(st_output);
+        }
+    }
+
+
     // AVFormat (cont.)
     avio_open(&(frame_ctx->av_format_ctx)->pb, output_filepath, AVIO_FLAG_WRITE);
     assert(!((frame_ctx->av_format_ctx)->oformat->flags & AVFMT_NOFILE));
@@ -422,6 +529,7 @@ request_video_capture(struct scran_output *st_output)
         // Ensure the first frame is fully rendered
         0, 0, st_output->mode.width_px, st_output->mode.height_px
     );
+    scran_pipewire_connect();
 
     st_output->capture.frame_ctx.capturing_video = true;
     atomic_fetch_add_explicit(&g_state.n_captures_in_progress, 1, memory_order_relaxed);
@@ -463,12 +571,28 @@ request_end_video_capture(struct scran_output *st_output)
 
 // Should only be called once the video capture event loop is finished.
 //    Call request_end_video_capture() instead to initiate graceful completion.
+// TODO: Rename this function to be less ambiguous now that we have audio as well.
 void
 end_video_capture(struct scran_output *st_output)
 {
     struct capture_frame_context *frame_ctx = &st_output->capture.frame_ctx;
 
-    // Drain codec
+    if (frame_ctx->audio_active) {
+        scran_pipewire_reset();
+
+        // Drain audio codec
+        avcodec_send_frame(frame_ctx->av_codec_ctx_audio, NULL);
+        assert(frame_ctx->av_packet_audio != NULL);
+        while (avcodec_receive_packet(frame_ctx->av_codec_ctx_audio, frame_ctx->av_packet_audio) != AVERROR_EOF) {
+            write_audio_packet(frame_ctx, frame_ctx->av_packet_audio);
+        }
+
+        destroy_ffmpeg_audio(st_output);
+
+        frame_ctx->audio_active = false;
+    }
+
+    // Drain video codec
     avcodec_send_frame(frame_ctx->av_codec_ctx, NULL);
     assert(frame_ctx->av_packet != NULL);
     while (avcodec_receive_packet(frame_ctx->av_codec_ctx, frame_ctx->av_packet) != AVERROR_EOF) {

--- a/src/event-handlers/image_copy_capture_frame__video_capture.c
+++ b/src/event-handlers/image_copy_capture_frame__video_capture.c
@@ -68,34 +68,6 @@ handle_image_copy_capture_frame_presentation_time__video_capture(
 }
 
 
-static inline void
-_write_video_frame(
-    struct capture_frame_context *frame_ctx,
-    AVPacket *av_packet // Encoded frame
-) {
-    assert(av_packet != NULL);
-
-    const AVStream *const _av_stream = frame_ctx->av_format_ctx->streams[AV_FORMAT_STREAM_IDX_VIDEO];
-
-    av_packet->stream_index = AV_FORMAT_STREAM_IDX_VIDEO;
-    assert(av_packet->stream_index == _av_stream->index);
-
-    // NOTE: This is doing the work of av_packet_rescale_ts(), but with
-    // asserts instead of conditionals. Just switch to that or to
-    // if-statements if indeterminism becomes necessary.
-    assert(av_packet->pts != AV_NOPTS_VALUE);
-    av_packet->pts = av_rescale_q(av_packet->pts, frame_ctx->av_codec_ctx->time_base, _av_stream->time_base);
-    assert(av_packet->dts != AV_NOPTS_VALUE);
-    av_packet->dts = av_rescale_q(av_packet->dts, frame_ctx->av_codec_ctx->time_base, _av_stream->time_base);
-
-    assert(av_packet->duration <= 0);
-
-    // TODO: Look into conditionally using av_write_frame for sequential
-    //       encoding
-    av_interleaved_write_frame(frame_ctx->av_format_ctx, av_packet);
-}
-
-
 // TODO:
 //  - Can we fully avoid capturing the overlay (beyond just 
 //    making sure it's out of frame) ?
@@ -155,7 +127,7 @@ handle_image_copy_capture_frame_ready__video_capture(
             return; // TODO: goto err
         }
 
-        _write_video_frame(frame_ctx, frame_ctx->av_packet);
+        write_video_frame(frame_ctx, frame_ctx->av_packet);
 
         // INFO: packet gets unreferenced at start of loop by avcodec_receive_packet
     }
@@ -191,13 +163,6 @@ handle_image_copy_capture_frame_ready__video_capture(
     return;
 
 end_capture:
-    // Drain codec
-    avcodec_send_frame(frame_ctx->av_codec_ctx, NULL);
-    assert(frame_ctx->av_packet != NULL);
-    while (avcodec_receive_packet(frame_ctx->av_codec_ctx, frame_ctx->av_packet) != AVERROR_EOF) {
-        _write_video_frame(frame_ctx, frame_ctx->av_packet);
-    }
-
     {
         struct scran_output_capture *const st_capture = wl_container_of(frame_ctx, st_capture, frame_ctx);
         struct scran_output *const st_output = wl_container_of(st_capture, st_output, capture);

--- a/src/event-handlers/image_copy_capture_frame__video_capture.c
+++ b/src/event-handlers/image_copy_capture_frame__video_capture.c
@@ -62,7 +62,7 @@ handle_image_copy_capture_frame_presentation_time__video_capture(
     struct capture_frame_context *frame_ctx = data;
 
     // XXX: Will overflow at tv_sec > ~584.9 years...
-    const uint64_t tv_sec_to_nsec = ((uint64_t)tv_sec_hi << 32 | tv_sec_lo) * NSEC_PER_SEC;
+    const int64_t tv_sec_to_nsec = ((uint64_t)tv_sec_hi << 32 | tv_sec_lo) * NSEC_PER_SEC;
 
     frame_ctx->presentation_time_nsec = tv_sec_to_nsec + tv_nsec - frame_ctx->presentation_time_nsec_start;
 }

--- a/src/event-handlers/image_copy_capture_frame__video_capture.c
+++ b/src/event-handlers/image_copy_capture_frame__video_capture.c
@@ -64,7 +64,7 @@ handle_image_copy_capture_frame_presentation_time__video_capture(
     // XXX: Will overflow at tv_sec > ~584.9 years...
     const uint64_t tv_sec_to_nsec = ((uint64_t)tv_sec_hi << 32 | tv_sec_lo) * NSEC_PER_SEC;
 
-    frame_ctx->presentation_time_nsec = tv_sec_to_nsec + tv_nsec;
+    frame_ctx->presentation_time_nsec = tv_sec_to_nsec + tv_nsec - frame_ctx->presentation_time_nsec_start;
 }
 
 

--- a/src/main.c
+++ b/src/main.c
@@ -33,6 +33,7 @@
 #include "signal-handlers.h"
 #include "util/blend2d.h"
 #include "portals.h"
+#include "pipewires.h"
 
 //  General TODO:
 //  - Don't use libwayland..? Handle its allocations etc. ourselves?
@@ -55,7 +56,7 @@ struct scran g_state = {
     },
 };
 
-#define SCRAN_EPOLL_SIZE 2 // XXX: hardcoded: dbus/portal + wayland
+#define SCRAN_EPOLL_SIZE 3 // XXX: hardcoded: dbus/portal + wayland + pipewire
 static struct epoll_event m_epoll_events[SCRAN_EPOLL_SIZE];
 static int m_epoll_fd = -1;
 
@@ -588,6 +589,8 @@ run_main_loop(struct _scran_signal_masks *signal_masks)
         assert(scran_portal_timeout_ms == -1);
     }
 
+    scran_pipewire_pre_init(m_epoll_fd);
+
     // Block/defer our signal handlers until explicit unblock during epoll
     if (sigprocmask(SIG_BLOCK, &signal_masks->with_scran_handlers_masked, NULL) == -1) {
         eprintf("sigprocmask failed: %s\n", strerror(errno));
@@ -633,8 +636,12 @@ run_main_loop(struct _scran_signal_masks *signal_masks)
         } else {
             bool wayland_ready = false;
             for (int i = 0; i < ret; ++i) {
-                if (m_epoll_events[i].data.fd == wl_display_fd) {
+                int ready_fd = m_epoll_events[i].data.fd;
+                if (ready_fd == wl_display_fd) {
                     wayland_ready = true;
+                } else {
+                    // XXX: This could be nicer. It currently checks its own fd.
+                    scran_pipewire_update(ready_fd);
                 }
             }
             if (wayland_ready) {
@@ -657,6 +664,8 @@ run_main_loop(struct _scran_signal_masks *signal_masks)
             g_state.sig_focus_requested = false;
         }
     };
+
+    scran_pipewire_destroy();
 
     return true;
 }

--- a/src/options.c
+++ b/src/options.c
@@ -475,6 +475,7 @@ static const char help_string[] =
     // TODO:
     // "  -ee  like -e, but ensure the scran process exits fully\n"
     // "         Equivalent to -Be"
+    "  -A   disable audio capture (during video capture)\n"
     "  -B   do not keep background process alive\n"
     "         Example: 'scran -B - | satty -f -'\n"
     "          By default, scran stays alive after exit to manage the clipboard\n"
@@ -512,12 +513,13 @@ scran_handle_args(int argc, char *const *argv)
     char *opt_output_directory = NULL;
 
     int opt;
-    while ((opt = getopt(argc, argv, "f:d:peBsg:Nh")) != -1) {
+    while ((opt = getopt(argc, argv, "f:d:peABsg:Nh")) != -1) {
         switch (opt) {
         case 'f': opt_filename                                          = optarg; break;
         case 'd': opt_output_directory                                  = optarg; break;
         case 'p': g_state.seat.pointer_ctx.use_presses_only             = true;   break;
         case 'e': g_state.options.capture_and_exit_after_selection_init = true;   break;
+        case 'A': g_state.options.disable_audio_capture                 = true;   break;
         case 'B': g_state.options.no_keepalive                          = true;   break;
         case 's': g_state.options.produce_slurp                         = true;   break;
         case 'g':

--- a/src/pipewires.c
+++ b/src/pipewires.c
@@ -1,0 +1,289 @@
+#include <stdbool.h>
+#include <sys/epoll.h>
+#include <assert.h>
+#include <stdatomic.h>
+
+#include <pipewire/pipewire.h>
+#include <spa/param/audio/format-utils.h>
+#include <spa/buffer/meta.h>
+#include <libavformat/avformat.h>
+#include <libavcodec/avcodec.h>
+#include <libavutil/audio_fifo.h>
+
+#include "pipewire/context.h"
+#include "pipewire/loop.h"
+#include "state.h"
+#include "pipewires.h"
+#include "capture.h"
+#include "print.h"
+
+
+extern struct scran g_state;
+
+
+static struct {
+    struct pw_loop               *loop;
+    struct pw_stream             *stream;
+    struct pw_context            *ctx;
+    struct pw_core               *core;
+    struct spa_hook               stream_listener;
+    struct capture_frame_context *userdata;
+    enum spa_audio_format format;
+    int loop_fd;
+    int epoll_fd;
+    bool pw_inited;
+} m_state = {
+    .epoll_fd = -1,
+    .loop_fd = -1,
+};
+
+
+static void
+on_process(void *data)
+{
+    struct capture_frame_context *frame_ctx = data;
+
+    if (!frame_ctx->capturing_video) {
+        // We need exit here, differently to our video frame handler, since
+        // on_process gets continuously requested automatically, and we can't
+        // safely stop it from within this handler.
+        return;
+    }
+
+    struct pw_buffer *pw_buf = pw_stream_dequeue_buffer(m_state.stream);
+    if (pw_buf == NULL) {
+        eprintf("Pipewire out of buffers\n");
+        return;
+    }
+
+    struct spa_buffer      *spa_buf     = pw_buf->buffer;
+    struct spa_meta_header *meta_header = spa_buffer_find_meta_data(spa_buf, SPA_META_Header, sizeof(*meta_header));
+
+    // XXX TODO: We obviously don't need this exact f32 format for sizeof(float)
+    // to be appropriate. Improve this assert once we don't hardcode the format
+    // anymore.
+    assert(  m_state.format    == SPA_AUDIO_FORMAT_F32P);
+    uint32_t bytes_per_sample   = sizeof(float);
+    uint32_t n_samples          = spa_buf->datas[0].chunk->size / bytes_per_sample;
+    // NOTE: n_samples_leftover must be adjusted if moved to after av_audio_fifo_write()
+    int      n_samples_leftover = av_audio_fifo_size(frame_ctx->av_audio_fifo);
+    // XXX TODO: FR/FL should be mapped to 0/1 dynamically.
+    void    *spa_buf_planes[SCRAN_PIPEWIRE_N_CHANNELS];
+
+    for (int i = 0; i < SCRAN_PIPEWIRE_N_CHANNELS; ++i) {
+        float *samples = spa_buf->datas[i].data;
+        if (samples == NULL) {
+            goto cont;
+        }
+        spa_buf_planes[i] = samples;
+    }
+    av_audio_fifo_write(frame_ctx->av_audio_fifo, spa_buf_planes, n_samples);
+
+
+    int64_t pts_incoming    = (meta_header != NULL) ? meta_header->pts : pw_buf->time;
+    int64_t pts_fifo_start  = pts_incoming
+                              - frame_ctx->presentation_time_nsec_start
+                              - av_rescale(n_samples_leftover, NSEC_PER_SEC, SCRAN_PIPEWIRE_SAMPLE_RATE);
+    int      frame_size     = frame_ctx->av_codec_ctx_audio->frame_size;
+
+    assert(frame_size == frame_ctx->av_frame_captured_audio->nb_samples);
+
+    int64_t pts_curr = pts_fifo_start;
+    while (av_audio_fifo_size(frame_ctx->av_audio_fifo) >= frame_size) {
+        av_audio_fifo_read(
+            frame_ctx->av_audio_fifo,
+            (void **)frame_ctx->av_frame_captured_audio->data,
+            frame_size
+        );
+
+        frame_ctx->av_frame_captured_audio->pts = pts_curr;
+
+        int ret_enc = avcodec_send_frame(frame_ctx->av_codec_ctx_audio, frame_ctx->av_frame_captured_audio);
+        if (ret_enc < 0) {
+            eprintf("Error while sending audio frame\n");
+            goto cont; // TODO: goto err?
+        }
+
+        while (ret_enc >= 0) {
+            ret_enc = avcodec_receive_packet(frame_ctx->av_codec_ctx_audio, frame_ctx->av_packet_audio);
+
+            if (ret_enc == AVERROR_EOF || ret_enc == AVERROR(EAGAIN)) {
+                break;
+            } else if (ret_enc < 0) {
+                eprintf("Error while encoding audio frame\n");
+                goto cont; // TODO: goto err?
+            }
+
+            write_audio_packet(frame_ctx, frame_ctx->av_packet_audio);
+        }
+
+        pts_curr += av_rescale(frame_size, NSEC_PER_SEC, SCRAN_PIPEWIRE_SAMPLE_RATE);
+    }
+
+    av_packet_unref(frame_ctx->av_packet_audio);
+
+cont:
+    pw_stream_queue_buffer(m_state.stream, pw_buf);
+    return;
+}
+
+
+static const struct pw_stream_events stream_events = {
+    PW_VERSION_STREAM_EVENTS,
+    .process = on_process,
+    // TODO: handle param_changed ?
+};
+
+
+// Deinit the pipewire listeners etc. without full pipewire deinit.
+// Must still call scran_pipewire_init() to restart again.
+void
+scran_pipewire_reset()
+{
+    if (m_state.stream != NULL) {
+        pw_stream_disconnect(m_state.stream);
+        spa_hook_remove(&m_state.stream_listener);
+        pw_stream_destroy(m_state.stream);
+        m_state.stream  = NULL;
+    }
+
+    if (m_state.core != NULL) {
+        pw_core_disconnect(m_state.core);
+        m_state.core = NULL;
+    }
+
+    if (m_state.ctx != NULL) {
+        pw_context_destroy(m_state.ctx);
+        m_state.ctx = NULL;
+    }
+
+    if (m_state.loop_fd != -1) {
+        epoll_ctl(m_state.epoll_fd, EPOLL_CTL_DEL, m_state.loop_fd, NULL);
+        m_state.loop_fd  = -1;
+    }
+
+    if (m_state.loop != NULL) {
+        pw_loop_leave(m_state.loop);
+        pw_loop_destroy(m_state.loop);
+        m_state.loop  = NULL;
+    }
+}
+
+// Full deinit
+void
+scran_pipewire_destroy()
+{
+    if (!m_state.pw_inited) {
+        return;
+    }
+
+    scran_pipewire_reset();
+    pw_deinit();
+}
+
+void
+scran_pipewire_pre_init(int epoll_fd)
+{
+    m_state.epoll_fd = epoll_fd;
+}
+
+// NOTE: scran_pipewire_pre_init() must be called first to set epoll fd
+//
+// TODO: Error-checking and destroy on failed init
+bool
+scran_pipewire_init(
+    struct capture_frame_context *frame_ctx,
+    enum spa_audio_format format
+) {
+    DEBUG("scran_pipewire_init()\n");
+
+    if (m_state.pw_inited == false) {
+        pw_init(NULL, NULL);
+        m_state.pw_inited = true;
+    }
+
+    m_state.loop    = pw_loop_new(NULL);
+    m_state.loop_fd = pw_loop_get_fd(m_state.loop);
+
+    assert(m_state.epoll_fd != -1);
+    struct epoll_event epoll_event = {
+        .events = EPOLLIN,
+        .data.fd = m_state.loop_fd
+    };
+    epoll_ctl(m_state.epoll_fd, EPOLL_CTL_ADD, m_state.loop_fd, &epoll_event);
+
+    m_state.ctx  = pw_context_new(    m_state.loop, NULL, 0);
+    m_state.core = pw_context_connect(m_state.ctx , NULL, 0);
+
+    // NOTE: pw_stream takes ownership of this. Don't free.
+    struct pw_properties *props = pw_properties_new(
+        PW_KEY_MEDIA_TYPE         , "Audio"  ,
+        PW_KEY_MEDIA_CATEGORY     , "Capture",
+        PW_KEY_MEDIA_ROLE         , "Screen" ,
+        PW_KEY_STREAM_CAPTURE_SINK, "true"   ,
+        NULL
+    );
+    m_state.stream = pw_stream_new(m_state.core, "scran-audio-capture", props);
+
+    m_state.userdata = frame_ctx;
+    m_state.format = format;
+
+    return true;
+}
+
+bool
+scran_pipewire_connect()
+{
+    pw_loop_enter(m_state.loop);
+    pw_stream_add_listener(m_state.stream, &m_state.stream_listener, &stream_events, m_state.userdata);
+
+    uint8_t buffer[1024];
+    struct spa_pod_builder builder = SPA_POD_BUILDER_INIT(buffer, sizeof(buffer));
+    const struct spa_pod *params[] =  {
+        spa_format_audio_raw_build(
+            &builder,
+            SPA_PARAM_EnumFormat,
+            &(struct spa_audio_info_raw){
+                .format   = m_state.format,
+                .rate     = SCRAN_PIPEWIRE_SAMPLE_RATE,
+                .channels = SCRAN_PIPEWIRE_N_CHANNELS
+            }
+        )
+    };
+
+    if (0 > pw_stream_connect(
+                m_state.stream,
+                SPA_DIRECTION_INPUT,
+                PW_ID_ANY,
+                PW_STREAM_FLAG_AUTOCONNECT
+                | PW_STREAM_FLAG_MAP_BUFFERS,
+                params,
+                sizeof(params) / sizeof(params[0]))
+    ) {
+        eprintf("Error: Failed to connect pipewire stream (%d: %s).\n", errno, strerror(errno));
+        return false;
+    }
+
+    DEBUG("Pipewire stream connected.\n");
+
+    return true;
+}
+
+
+bool
+scran_pipewire_update(int fd_ready)
+{
+    if (fd_ready != m_state.loop_fd) {
+        return true;
+    }
+
+    assert(m_state.loop != NULL);
+
+    if (0 > pw_loop_iterate(m_state.loop, 0)) {
+        eprintf("Error: Failed to iterate pipewire loop\n");
+        return false;
+    }
+
+    return true;
+}
+

--- a/src/util/lib-interop.c
+++ b/src/util/lib-interop.c
@@ -8,6 +8,7 @@
 
 #include "util/lib-interop.h"
 #include "capture.h"
+#include "spa/param/audio/raw.h"
 
 
 // XXX TODO: Verify that this assignment happens at compile time.
@@ -152,6 +153,33 @@ wl_output_transform_to_ffmpeg_transpose_dir__inverse(enum wl_output_transform tr
         case WL_OUTPUT_TRANSFORM_FLIPPED:     return SCRAN_AV_TRANSPOSE_DIR_FLIPPED;
         case WL_OUTPUT_TRANSFORM_FLIPPED_90:  return SCRAN_AV_TRANSPOSE_DIR_FLIPPED_270;
         case WL_OUTPUT_TRANSFORM_FLIPPED_270: return SCRAN_AV_TRANSPOSE_DIR_FLIPPED_90;
+    }
+}
+
+enum spa_audio_format
+ffmpeg_sample_format_to_pipewire(enum AVSampleFormat format)
+{
+    // XXX TODO: Revisit the SPA_AUDIO_FORMAT_UNKNOWN assignments once they
+    // might actually become relevant/selected.
+
+    switch (format) {
+        case AV_SAMPLE_FMT_NONE: return SPA_AUDIO_FORMAT_UNKNOWN;
+
+        case AV_SAMPLE_FMT_U8:   return SPA_AUDIO_FORMAT_U8;
+        case AV_SAMPLE_FMT_S16:  return SPA_AUDIO_FORMAT_S16;
+        case AV_SAMPLE_FMT_S32:  return SPA_AUDIO_FORMAT_S32;
+        case AV_SAMPLE_FMT_FLT:  return SPA_AUDIO_FORMAT_F32;
+        case AV_SAMPLE_FMT_DBL:  return SPA_AUDIO_FORMAT_F64;
+
+        case AV_SAMPLE_FMT_U8P:  return SPA_AUDIO_FORMAT_U8P;
+        case AV_SAMPLE_FMT_S16P: return SPA_AUDIO_FORMAT_S16P;
+        case AV_SAMPLE_FMT_S32P: return SPA_AUDIO_FORMAT_S32P;
+        case AV_SAMPLE_FMT_FLTP: return SPA_AUDIO_FORMAT_F32P;
+        case AV_SAMPLE_FMT_DBLP: return SPA_AUDIO_FORMAT_F64P;
+        case AV_SAMPLE_FMT_S64:  return SPA_AUDIO_FORMAT_UNKNOWN;
+        case AV_SAMPLE_FMT_S64P: return SPA_AUDIO_FORMAT_UNKNOWN;
+
+        default:                 return SPA_AUDIO_FORMAT_UNKNOWN;
     }
 }
 


### PR DESCRIPTION
- Added audio through pipewire
  - libpipewire dependency added
  - `-A` to disable audio capture during video capture
  - Currently hard-coded to use:
    - AAC
    - 2-channel stereo
    - 48khz sample rate
- Video presentation time fixed (both for audio and video)
  - Starts from 0-ish now, rather than whatever monotonic clock happened to be at