### PR TITLE
Fix -g / custom initial selection

### DIFF
--- a/include/selection.h
+++ b/include/selection.h
@@ -1,6 +1,8 @@
 #ifndef SCRAN_SELECTION_H
 #define SCRAN_SELECTION_H
 
+#include <blend2d/blend2d.h>
+
 #include "state.h"
 
 
@@ -8,6 +10,8 @@
 #define SCRAN_LAYER_SURFACE_KEYBOARD_INTERACTIVITY_UNFOCUSED ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_NONE
 
 #define SCRAN_BTN_NONE 0 // linux/input-event-codes.h: #define KEY_RESERVED 0
+
+#define SCRAN_INITIAL_SELECTION_NONE ((BLBoxI){ -1, -1, -1, -1 })
 
 
 enum surface_theme {

--- a/src/init/selection.c
+++ b/src/init/selection.c
@@ -134,13 +134,10 @@ init_postmem__selection(struct scran_output *st_output, BLBoxI *custom_initial_s
         );
         bl_context_init_as(&st_buffer->bl_ctx, &st_buffer->bl_img, NULL);
     }
-
     bl_path_init(&selection_surface->bl_path);
 
-    enum surface_theme theme             = (custom_initial_selection != NULL) ? SURFACE_THEME_DEFAULT : SURFACE_THEME_PRE_SELECTION;
-    BLBoxI             initial_selection = (custom_initial_selection != NULL) ? *custom_initial_selection : (BLBoxI){ };
-    st_output->initial_selection = initial_selection;
-    set_selection_surface_theme(st_output, theme);
+    // Must be set prior to init_selection_surface_content().
+    st_output->initial_selection = (custom_initial_selection != NULL) ? *custom_initial_selection : SCRAN_INITIAL_SELECTION_NONE;
 
     // If we freezeframe, then we must initialize the selection surface from
     // within the freezeframe callback, to make sure we don't "freeze" an

--- a/src/main.c
+++ b/src/main.c
@@ -576,7 +576,7 @@ init_postmem()
     struct scran_output *custom_initial_selection_output = NULL;
 
     if (g_state.options.have_custom_initial_selection) {
-        struct BLRectI      custom_initial_selection_rect;
+        struct BLRectI custom_initial_selection_rect;
         global_logical_rect_to_selection(
             g_state.options.custom_initial_selection_global_coordinates,
             &custom_initial_selection_rect,
@@ -587,11 +587,7 @@ init_postmem()
             eprintf("Error: Top left corner of geometry string is not within any detected output.\n");
             return false;
         }
-
         custom_initial_selection = blrecti_to_blboxi(custom_initial_selection_rect);
-
-        scran_ui_set_selection_stage_defaults(&custom_initial_selection_output->selection_surface.ui_ctx);
-        set_selection_initialized(custom_initial_selection_output);
     }
 
     FOR_EACH_OUTPUT(i, st_output) {

--- a/src/selection-surface.c
+++ b/src/selection-surface.c
@@ -2,6 +2,7 @@
 
 #include <blend2d/blend2d.h>
 
+#include "selection.h"
 #include "state.h"
 #include "selection-surface.h"
 #include "init.h"
@@ -405,9 +406,28 @@ init_selection_surface_content(
     struct scran_output_selectionSurface *selection_surface = &st_output->selection_surface;
     struct BLBoxI                         initial_box       =  st_output->initial_selection;
 
+    const bool no_initial_selection = blboxi_are_equal(initial_box, SCRAN_INITIAL_SELECTION_NONE);
+
+    if (no_initial_selection) {
+        // We want to draw the splash text in the top left corner.
+        initial_box = (BLBoxI){0};
+        st_output->selection_ctx.box_px = initial_box;
+        set_selection_surface_theme(st_output, SURFACE_THEME_PRE_SELECTION);
+    } else {
+        // This must be set prior to set_selection_initialized()
+        st_output->selection_ctx.box_px = initial_box;
+        // These are usually called at "runtime"/main-loop-time, so call these
+        // AFTER init_postmem__selection(), to ensure all relevant runtime
+        // state has been set up.
+        // ALSO make sure it's called somewhere that the freezeframe init path
+        // (and potential future alternate init paths) will reach.
+        scran_ui_set_selection_stage_defaults(&selection_surface->ui_ctx);
+        set_selection_surface_theme(st_output, SURFACE_THEME_DEFAULT);
+        set_selection_initialized(st_output);
+    }
+
     for (int i = 0; i < SELECTION_SURFACE_BUF_COUNT; ++i) {
         struct scran_output_selectionSurface_buffer *st_buffer = &selection_surface->double_buffer[i];
-
         // Initialized as busy; reset them now.
         //   See init_premem__selection() for more info
         assert(st_buffer->busy == true);
@@ -418,8 +438,6 @@ init_selection_surface_content(
             initial_box
         );
     }
-
-    st_output->selection_ctx.box_px = initial_box;
 
     struct scran_output_selectionSurface_buffer *initial_buffer = &selection_surface->double_buffer[0];
     initial_buffer->busy = true;


### PR DESCRIPTION
Was broken when combined with -e due to `set_selection_initialized()` being called too early.