### PR TITLE
Transfer seat state to new surface

### DIFF
--- a/include/seat.h
+++ b/include/seat.h
@@ -4,14 +4,52 @@
 
 #include <wayland-client-core.h>
 
+#include "state.h"
 #include "state-util.h"
 
 
+void seat_apply_mod_key_state(struct scran_seat *seat, struct scran_output_selectionSurface *selection_surface, bool state);
+
 static inline void
-seat_update_focused_selection_surface(
+seat_set_mod_key_state(struct scran_seat *seat, bool state) {
+    seat_apply_mod_key_state(seat, seat->active_selection_surface, state);
+    seat->mod_key_active = state;
+}
+
+static inline void
+seat_update_active_selection_surface(struct scran_seat *seat) {
+
+    // When multiple same-layer layer surface request ECXLUSIVE keyboard
+    // interactivity, it is implementation-defined which surface gets keyboard
+    // focus, so prioritize the pointer's focused surface, if available.
+    //
+    // COSMIC, as of recently started only giving keyboard focus to the "main"
+    // display's selection surface.
+    //
+    // We control all our surfaces, so it doesn't matter if our "real" keyboard
+    // focus is on a different surface/output.
+
+    struct scran_output_selectionSurface *selected_surface =
+        seat->pointer_ctx.focused_selection_surface
+        ?: seat->keyboard.focused_selection_surface;
+
+    if (selected_surface != seat->active_selection_surface) {
+        seat_apply_mod_key_state(seat, seat->active_selection_surface, false);
+        seat_apply_mod_key_state(seat, selected_surface, seat->mod_key_active);
+        seat->active_selection_surface = selected_surface;
+    }
+}
+
+static inline void
+seat_set_focused_selection_surface_(
     struct scran_output_selectionSurface **dst,
     struct wl_surface *focused_surface
 ) {
+    if (focused_surface == NULL) {
+        *dst = NULL;
+        return;
+    }
+
     FOR_EACH_OUTPUT(i, st_output) {
         struct scran_output_selectionSurface *selection_surface = &st_output->selection_surface;
         if (focused_surface == selection_surface->surface.wl_surface) {
@@ -35,5 +73,24 @@ seat_update_focused_selection_surface(
     return;
 }
 
+static inline struct scran_output_selectionSurface *
+seat_update_pointer_focus(struct scran_seat *seat, struct wl_surface *focused_surface) {
+    struct scran_output_selectionSurface **pointer_focused_surface = &seat->pointer_ctx.focused_selection_surface;
+
+    seat_set_focused_selection_surface_(&seat->pointer_ctx.focused_selection_surface, focused_surface);
+    seat_update_active_selection_surface(seat);
+
+    return *pointer_focused_surface;
+}
+
+static inline struct scran_output_selectionSurface *
+seat_update_keyboard_focus(struct scran_seat *seat, struct wl_surface *focused_surface) {
+    struct scran_output_selectionSurface **keyboard_focused_surface = &seat->keyboard.focused_selection_surface;
+
+    seat_set_focused_selection_surface_(keyboard_focused_surface, focused_surface);
+    seat_update_active_selection_surface(seat);
+
+    return *keyboard_focused_surface;
+}
 
 #endif

--- a/include/seat.h
+++ b/include/seat.h
@@ -9,35 +9,12 @@
 
 
 void seat_apply_mod_key_state(struct scran_seat *seat, struct scran_output_selectionSurface *selection_surface, bool state);
+void seat_update_active_selection_surface(struct scran_seat *seat);
 
 static inline void
 seat_set_mod_key_state(struct scran_seat *seat, bool state) {
     seat_apply_mod_key_state(seat, seat->active_selection_surface, state);
     seat->mod_key_active = state;
-}
-
-static inline void
-seat_update_active_selection_surface(struct scran_seat *seat) {
-
-    // When multiple same-layer layer surface request ECXLUSIVE keyboard
-    // interactivity, it is implementation-defined which surface gets keyboard
-    // focus, so prioritize the pointer's focused surface, if available.
-    //
-    // COSMIC, as of recently started only giving keyboard focus to the "main"
-    // display's selection surface.
-    //
-    // We control all our surfaces, so it doesn't matter if our "real" keyboard
-    // focus is on a different surface/output.
-
-    struct scran_output_selectionSurface *selected_surface =
-        seat->pointer_ctx.focused_selection_surface
-        ?: seat->keyboard.focused_selection_surface;
-
-    if (selected_surface != seat->active_selection_surface) {
-        seat_apply_mod_key_state(seat, seat->active_selection_surface, false);
-        seat_apply_mod_key_state(seat, selected_surface, seat->mod_key_active);
-        seat->active_selection_surface = selected_surface;
-    }
 }
 
 static inline void

--- a/include/state.h
+++ b/include/state.h
@@ -289,6 +289,9 @@ struct scran_seat {
     struct wl_pointer *wl_pointer;
     struct wl_keyboard *wl_keyboard;
     // TODO: struct wl_touch *touch;
+
+    struct scran_output_selectionSurface *active_selection_surface;
+    bool mod_key_active;
 };
 
 enum selection_state {

--- a/include/ui.h
+++ b/include/ui.h
@@ -250,6 +250,23 @@ scran_ui_statusline_set_timer(
     return false;
 }
 
+static inline uint32_t
+scran_ui_textline_item_get_pressed_mask(
+    struct scran_ui_textline_view textline
+) {
+    return textline.meta->pressed_items_mask;
+}
+
+static inline void
+scran_ui_textline_item_set_pressed_mask(
+    struct scran_ui_context *ui_ctx,
+    struct scran_ui_textline_view textline,
+    uint32_t pressed_items_mask
+) {
+    textline.meta->dirty_items_mask |= pressed_items_mask ^ textline.meta->pressed_items_mask;
+    textline.meta->pressed_items_mask = pressed_items_mask;
+}
+
 static inline void
 scran_ui_textline_item_set_pressed(
     struct scran_ui_context *ui_ctx,

--- a/meson.build
+++ b/meson.build
@@ -56,6 +56,7 @@ scran_sources = files(
   'src/options.c',
   'src/pipewires.c',
   'src/dbus.c',
+  'src/seat.c',
   'src/selection.c',
   'src/selection-surface.c',
   'src/signal-handlers.c',

--- a/src/event-handlers/keyboard.c
+++ b/src/event-handlers/keyboard.c
@@ -65,9 +65,7 @@ handle_keyboard_enter (
     struct wl_array *keys
 ) {
     struct scran *state = data;
-    struct scran_seat_keyboard *keyboard_ctx = &state->seat.keyboard;
-
-    seat_update_focused_selection_surface(&keyboard_ctx->focused_selection_surface, surface_entered);
+    seat_update_keyboard_focus(&state->seat, surface_entered);
 }
 
 
@@ -76,12 +74,10 @@ handle_keyboard_leave (
     void *data,
     struct wl_keyboard *wl_keyboard,
     uint32_t serial,
-    struct wl_surface *surface
+    struct wl_surface *surface_left
 ) {
     struct scran *state = data;
-    struct scran_seat_keyboard *keyboard_ctx = &state->seat.keyboard;
-
-    keyboard_ctx->focused_selection_surface = NULL;
+    seat_update_keyboard_focus(&state->seat, NULL);
 }
 
 
@@ -95,14 +91,14 @@ handle_keyboard_key(
     enum wl_keyboard_key_state key_state
 ) {
     struct scran *state = data;
-    struct scran_output_selectionSurface *focused_selection_surface = state->seat.keyboard.focused_selection_surface;
+    struct scran_output_selectionSurface *active_selection_surface = state->seat.active_selection_surface;
 
-    if (focused_selection_surface == NULL) {
+    if (active_selection_surface == NULL) {
         return;
     }
 
-    struct scran_output          *st_output    = wl_container_of(focused_selection_surface, st_output, selection_surface);
-    struct scran_ui_context      *ui_ctx       = &focused_selection_surface->ui_ctx;
+    struct scran_output          *st_output    = wl_container_of(active_selection_surface, st_output, selection_surface);
+    struct scran_ui_context      *ui_ctx       = &active_selection_surface->ui_ctx;
 
     // Only xkb key format supported
     assert(state->seat.keyboard.xkb_state != NULL);
@@ -300,39 +296,10 @@ handle_keyboard_modifiers(
         group
     );
 
-    struct scran_output_selectionSurface *focused_selection_surface = state->seat.keyboard.focused_selection_surface;
-
-    if (focused_selection_surface == NULL) {
-        return;
-    }
-
-    struct scran_output *st_output = wl_container_of(focused_selection_surface, st_output, selection_surface);
-
-    bool mod_key_active = xkb_state_mod_name_is_active(state->seat.keyboard.xkb_state, XKB_MOD_NAME_SHIFT, XKB_STATE_EFFECTIVE);
-
-    {
-        struct scran_ui_context *ui_ctx = &focused_selection_surface->ui_ctx;
-
-        if (mod_key_active) {
-            scran_ui_textline_item_set_text( ui_ctx, SCRAN_UI_TEXTLINE_VIEW(ui_ctx->ui_keymap), SCRAN_UI_KEYMAP_ITEM_I_IMAGE, SCRAN_UI_TEXT_KEYMAP_IMAGE_MOD);
-            scran_ui_textline_item_set_color(ui_ctx, SCRAN_UI_TEXTLINE_VIEW(ui_ctx->ui_keymap), SCRAN_UI_KEYMAP_ITEM_I_IMAGE, SCRAN_UI_COLOR_KEYMAP_MOD);
-            scran_ui_textline_item_set_text( ui_ctx, SCRAN_UI_TEXTLINE_VIEW(ui_ctx->ui_keymap), SCRAN_UI_KEYMAP_ITEM_I_VIDEO, SCRAN_UI_TEXT_KEYMAP_VIDEO_MOD);
-            scran_ui_textline_item_set_color(ui_ctx, SCRAN_UI_TEXTLINE_VIEW(ui_ctx->ui_keymap), SCRAN_UI_KEYMAP_ITEM_I_VIDEO, SCRAN_UI_COLOR_KEYMAP_MOD);
-        } else {
-            scran_ui_textline_item_set_text( ui_ctx, SCRAN_UI_TEXTLINE_VIEW(ui_ctx->ui_keymap), SCRAN_UI_KEYMAP_ITEM_I_IMAGE, SCRAN_UI_TEXT_KEYMAP_IMAGE_DEFAULT);
-            scran_ui_textline_item_set_color(ui_ctx, SCRAN_UI_TEXTLINE_VIEW(ui_ctx->ui_keymap), SCRAN_UI_KEYMAP_ITEM_I_IMAGE, SCRAN_UI_COLOR_DEFAULT);
-            scran_ui_textline_item_set_text( ui_ctx, SCRAN_UI_TEXTLINE_VIEW(ui_ctx->ui_keymap), SCRAN_UI_KEYMAP_ITEM_I_VIDEO, SCRAN_UI_TEXT_KEYMAP_VIDEO_DEFAULT);
-            scran_ui_textline_item_set_color(ui_ctx, SCRAN_UI_TEXTLINE_VIEW(ui_ctx->ui_keymap), SCRAN_UI_KEYMAP_ITEM_I_VIDEO, SCRAN_UI_COLOR_DEFAULT);
-        }
-
-        // This is only used during video init, so just set this unconditionally
-        // to avoid future possible sticky key bugs...
-        // TODO: Probably merge the authority for these things into the ui code,
-        // especially if we want to support mouse clicks.
-        st_output->capture.frame_ctx.audio_disable_modifier_active = mod_key_active;
-
-        request_selection_surface_frame_callback(st_output);
-    }
+    seat_set_mod_key_state(
+        &state->seat,
+        xkb_state_mod_name_is_active(state->seat.keyboard.xkb_state, XKB_MOD_NAME_SHIFT, XKB_STATE_EFFECTIVE)
+    );
 }
 
 

--- a/src/event-handlers/pointer.c
+++ b/src/event-handlers/pointer.c
@@ -28,9 +28,9 @@ handle_pointer_enter(
 
     pointer_ctx->last_enter_serial = serial;
 
-    seat_update_focused_selection_surface(&pointer_ctx->focused_selection_surface, surface_entered);
+    struct scran_output_selectionSurface *pointer_surface = seat_update_pointer_focus(&state->seat, surface_entered);
 
-    if (pointer_ctx->focused_selection_surface != NULL) {
+    if (pointer_surface && pointer_surface == state->seat.active_selection_surface) {
         struct scran_output *st_output = wl_container_of(
             pointer_ctx->focused_selection_surface, st_output, selection_surface
         );
@@ -48,9 +48,7 @@ handle_pointer_leave(
     struct wl_surface *surface_left
 ) {
     struct scran *state = data;
-    struct scran_seat_pointerContext *pointer_ctx = &state->seat.pointer_ctx;
-
-    pointer_ctx->focused_selection_surface = NULL;
+    seat_update_pointer_focus(&state->seat, NULL);
 }
 
 

--- a/src/seat.c
+++ b/src/seat.c
@@ -1,6 +1,8 @@
 #include "seat.h"
 #include "selection-surface.h"
 #include "state.h"
+#include "ui.h"
+
 
 void
 seat_apply_mod_key_state(
@@ -35,3 +37,66 @@ seat_apply_mod_key_state(
 
     request_selection_surface_frame_callback(st_output);
 }
+
+// TODO: Probably store pressed state in scran_seat.
+
+static inline uint32_t
+get_keymap_pressed_state(
+    struct scran_seat *seat,
+    struct scran_output_selectionSurface *selection_surface
+) {
+    if(!selection_surface) {
+        return 0;
+    }
+    return scran_ui_textline_item_get_pressed_mask(
+        SCRAN_UI_TEXTLINE_VIEW(selection_surface->ui_ctx.ui_keymap)
+    );
+}
+
+static inline void
+set_keymap_pressed_state(
+    struct scran_output_selectionSurface *selection_surface,
+    uint32_t pressed_mask
+) {
+    if(!selection_surface) {
+        return;
+    }
+
+    struct scran_output     *st_output = wl_container_of(selection_surface, st_output, selection_surface);
+    struct scran_ui_context *ui_ctx    = &st_output->selection_surface.ui_ctx;
+
+    scran_ui_textline_item_set_pressed_mask(ui_ctx, SCRAN_UI_TEXTLINE_VIEW(ui_ctx->ui_keymap), pressed_mask);
+
+    request_selection_surface_frame_callback(st_output);
+}
+
+void
+seat_update_active_selection_surface(struct scran_seat *seat)
+{
+    // When multiple same-layer layer surface request ECXLUSIVE keyboard
+    // interactivity, it is implementation-defined which surface gets keyboard
+    // focus, so prioritize the pointer's focused surface, if available.
+    //
+    // COSMIC, as of recently started only giving keyboard focus to the "main"
+    // display's selection surface.
+    //
+    // We control all our surfaces, so it doesn't matter if our "real" keyboard
+    // focus is on a different surface/output.
+
+    struct scran_output_selectionSurface *new_surface =
+        seat->pointer_ctx.focused_selection_surface
+        ?: seat->keyboard.focused_selection_surface;
+
+    if (new_surface != seat->active_selection_surface) {
+        const uint32_t old_keymap_state = get_keymap_pressed_state(seat, seat->active_selection_surface);
+
+        seat_apply_mod_key_state(seat, seat->active_selection_surface, false);
+        set_keymap_pressed_state(seat->active_selection_surface, 0);
+
+        seat_apply_mod_key_state(seat, new_surface, seat->mod_key_active);
+        set_keymap_pressed_state(new_surface, old_keymap_state);
+
+        seat->active_selection_surface = new_surface;
+    }
+}
+

--- a/src/seat.c
+++ b/src/seat.c
@@ -1,0 +1,37 @@
+#include "seat.h"
+#include "selection-surface.h"
+#include "state.h"
+
+void
+seat_apply_mod_key_state(
+    struct scran_seat *seat,
+    struct scran_output_selectionSurface *selection_surface,
+    bool state
+) {
+    if(!selection_surface) {
+        return;
+    }
+
+    struct scran_output     *st_output = wl_container_of(selection_surface, st_output, selection_surface);
+    struct scran_ui_context *ui_ctx    = &st_output->selection_surface.ui_ctx;
+
+    if (state) {
+        scran_ui_textline_item_set_text( ui_ctx, SCRAN_UI_TEXTLINE_VIEW(ui_ctx->ui_keymap), SCRAN_UI_KEYMAP_ITEM_I_IMAGE, SCRAN_UI_TEXT_KEYMAP_IMAGE_MOD);
+        scran_ui_textline_item_set_color(ui_ctx, SCRAN_UI_TEXTLINE_VIEW(ui_ctx->ui_keymap), SCRAN_UI_KEYMAP_ITEM_I_IMAGE, SCRAN_UI_COLOR_KEYMAP_MOD);
+        scran_ui_textline_item_set_text( ui_ctx, SCRAN_UI_TEXTLINE_VIEW(ui_ctx->ui_keymap), SCRAN_UI_KEYMAP_ITEM_I_VIDEO, SCRAN_UI_TEXT_KEYMAP_VIDEO_MOD);
+        scran_ui_textline_item_set_color(ui_ctx, SCRAN_UI_TEXTLINE_VIEW(ui_ctx->ui_keymap), SCRAN_UI_KEYMAP_ITEM_I_VIDEO, SCRAN_UI_COLOR_KEYMAP_MOD);
+    } else {
+        scran_ui_textline_item_set_text( ui_ctx, SCRAN_UI_TEXTLINE_VIEW(ui_ctx->ui_keymap), SCRAN_UI_KEYMAP_ITEM_I_IMAGE, SCRAN_UI_TEXT_KEYMAP_IMAGE_DEFAULT);
+        scran_ui_textline_item_set_color(ui_ctx, SCRAN_UI_TEXTLINE_VIEW(ui_ctx->ui_keymap), SCRAN_UI_KEYMAP_ITEM_I_IMAGE, SCRAN_UI_COLOR_DEFAULT);
+        scran_ui_textline_item_set_text( ui_ctx, SCRAN_UI_TEXTLINE_VIEW(ui_ctx->ui_keymap), SCRAN_UI_KEYMAP_ITEM_I_VIDEO, SCRAN_UI_TEXT_KEYMAP_VIDEO_DEFAULT);
+        scran_ui_textline_item_set_color(ui_ctx, SCRAN_UI_TEXTLINE_VIEW(ui_ctx->ui_keymap), SCRAN_UI_KEYMAP_ITEM_I_VIDEO, SCRAN_UI_COLOR_DEFAULT);
+    }
+
+    // This is only used during video init, so just set this unconditionally
+    // to avoid future possible sticky key bugs...
+    // TODO: Probably merge the authority for these things into the ui code,
+    // especially if we want to support mouse clicks.
+    st_output->capture.frame_ctx.audio_disable_modifier_active = state;
+
+    request_selection_surface_frame_callback(st_output);
+}


### PR DESCRIPTION
Transfer mod key and keymap pressed state when moving to a different surface/output.

Previously, the state was just stuck until moving back again and doing an action (like another keypress/depress) that triggered an update.