### PR TITLE
Make freezeframe always available

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ See `scran -h` for more details
          Note: audio capture requires PipeWire.
   -C   disable cursor capture
   -B   do not keep background process alive
-  -z   freeze the display at startup
+  -z   automatically freeze the display at startup
   -s   slurp: send selection as geometry string to standard output
          Equivalent to slurp's default output.
          See https://wayland.emersion.fr/slurp/.

--- a/include/state.h
+++ b/include/state.h
@@ -468,7 +468,7 @@ struct scran_options {
     bool no_keepalive;
     bool disable_audio_capture;
     bool disable_cursor_capture;
-    bool freezeframe;
+    bool freezeframe_at_startup;
     bool capture_and_exit_after_selection_init;
     bool produce_slurp;                 // output slurp-style geometry string
     bool no_notifications;

--- a/src/event-handlers/keyboard.c
+++ b/src/event-handlers/keyboard.c
@@ -124,9 +124,7 @@ handle_keyboard_key(
             break;
         case XKB_KEY_z:
         case XKB_KEY_Z:
-            if (state->options.freezeframe) {
-                scran_ui_textline_item_set_pressed(ui_ctx, SCRAN_UI_TEXTLINE_VIEW(ui_ctx->ui_keymap), SCRAN_UI_KEYMAP_ITEM_I_FREEZEFRAME, false);
-            }
+            scran_ui_textline_item_set_pressed(ui_ctx, SCRAN_UI_TEXTLINE_VIEW(ui_ctx->ui_keymap), SCRAN_UI_KEYMAP_ITEM_I_FREEZEFRAME, false);
             break;
         default:
             return;
@@ -167,10 +165,6 @@ handle_keyboard_key(
         break;
     case XKB_KEY_z:
     case XKB_KEY_Z:
-        if (!state->options.freezeframe) {
-            break;
-        }
-
         {
             struct scran_ui_context *ui_ctx = &st_output->selection_surface.ui_ctx;
             scran_ui_textline_item_set_pressed(ui_ctx, SCRAN_UI_TEXTLINE_VIEW(ui_ctx->ui_keymap), SCRAN_UI_KEYMAP_ITEM_I_FREEZEFRAME, true);

--- a/src/event-handlers/keyboard.c
+++ b/src/event-handlers/keyboard.c
@@ -190,8 +190,6 @@ handle_keyboard_key(
 
         // XXX TODO: Make this a bit cleaner responsibility-wise.
         //             See also refactor-TODO in unhide_selection_surface().
-        //           Also, maybe make this the only (default) way to toggle freezeframe,
-        //           and don't let refocus automatically re-freeze?
         if (pretend_all_hidden) {
             FOR_EACH_OUTPUT(i, st_output) {
                 freezeframe_capture_refresh(st_output, start_grabbing_focus_for_output);

--- a/src/freezeframe.c
+++ b/src/freezeframe.c
@@ -56,6 +56,10 @@ freezeframe_hide_surface(struct scran_output *st_output)
 {
     struct scran_output_freezeframe *freezeframe = &st_output->freezeframe;
 
+    if (!freezeframe->showing) {
+        return;
+    }
+
     // NOTE(!!): We need to actually unmap this surface, and not just
     // attach a transparent buffer, since attaching a transparent
     // buffer causes some compositors (e.g. Sway) to not properly

--- a/src/init/selection.c
+++ b/src/init/selection.c
@@ -142,7 +142,7 @@ init_postmem__selection(struct scran_output *st_output, BLBoxI *custom_initial_s
     // If we freezeframe, then we must initialize the selection surface from
     // within the freezeframe callback, to make sure we don't "freeze" an
     // already dimmed (our UI dim) frame. TODO: Make this a bit neater?
-    if (g_state.options.freezeframe) {
+    if (g_state.options.freezeframe_at_startup) {
         // This commits the surface in the capture-frame::ready handler, handing
         // over the wl_buffer containing the captured freezeframe.
         freezeframe_capture_start(st_output, init_selection_surface_content);

--- a/src/main.c
+++ b/src/main.c
@@ -118,10 +118,8 @@ init_premem()
             return false;
         }
 
-        if (g_state.options.freezeframe) {
-            if (!init_premem__freezeframe(st_output)) {
-                return false;
-            }
+        if (!init_premem__freezeframe(st_output)) {
+            return false;
         }
 
         st_output->xdg_output = zxdg_output_manager_v1_get_xdg_output(
@@ -246,9 +244,7 @@ init_premem__destroy()
     registry_listener__destroy(&g_state);
 
     FOR_EACH_OUTPUT(i, st_output) {
-        if (g_state.options.freezeframe) {
-            init_premem__freezeframe__destroy(st_output);
-        }
+        init_premem__freezeframe__destroy(st_output);
         init_premem__cursor__destroy(st_output);
         init_premem__selection__destroy(st_output);
         init_premem__capture__destroy(st_output);
@@ -413,32 +409,28 @@ init_meminit(
             );
         }
 
-        const size_t capture_buf_size = get_capture_buf_size(st_output);
-
-        if (g_state.options.freezeframe) {
-            if (st_output->freezeframe.shm_format == SCRAN_SHM_FORMAT_UNSET) {
-                DEBUG("Failed to select shm_format for freezeframe capture buffer.\n");
-                return false;
-            }
-
-            // XXX: We use a separate capture buffer and surface buffer due to
-            // wl_surface::set_buffer_transform not working as expected in
-            // Hyprland (#14441).
-            const size_t freezeframe_buf_size = get_framebuffer_size(
-                st_output->freezeframe.source_width_px,
-                st_output->freezeframe.source_height_px,
-                SURFACE_PIXEL_STRIDE
-            );
-            scran_arena_add_block(
-                shm_arena,
-                freezeframe_buf_size, FRAMEBUFFER_ALIGNMENT_BYTES, &st_output->freezeframe.capture_buffer.scran_wl_buffer.data
-            );
-            scran_arena_add_block(
-                shm_arena,
-                freezeframe_buf_size, FRAMEBUFFER_ALIGNMENT_BYTES, &st_output->freezeframe.surface_buffer.scran_wl_buffer.data
-            );
+        if (st_output->freezeframe.shm_format == SCRAN_SHM_FORMAT_UNSET) {
+            DEBUG("Failed to select shm_format for freezeframe capture buffer.\n");
+            return false;
         }
+        // XXX: We use a separate capture buffer and surface buffer due to
+        // wl_surface::set_buffer_transform not working as expected in
+        // Hyprland (#14441).
+        const size_t freezeframe_buf_size = get_framebuffer_size(
+            st_output->freezeframe.source_width_px,
+            st_output->freezeframe.source_height_px,
+            SURFACE_PIXEL_STRIDE
+        );
+        scran_arena_add_block(
+            shm_arena,
+            freezeframe_buf_size, FRAMEBUFFER_ALIGNMENT_BYTES, &st_output->freezeframe.capture_buffer.scran_wl_buffer.data
+        );
+        scran_arena_add_block(
+            shm_arena,
+            freezeframe_buf_size, FRAMEBUFFER_ALIGNMENT_BYTES, &st_output->freezeframe.surface_buffer.scran_wl_buffer.data
+        );
 
+        const size_t capture_buf_size = get_capture_buf_size(st_output);
         scran_arena_add_block(
             shm_arena,
             capture_buf_size, FRAMEBUFFER_ALIGNMENT_BYTES, &st_output->capture.frame_ctx.scran_wl_buffer.data
@@ -531,7 +523,7 @@ init_meminit(
             );
         }
 
-        if (g_state.options.freezeframe) {
+        {
             struct scran_output_freezeframe *freezeframe = &st_output->freezeframe;
 
             struct scran_freezeframe_buffer *capture_buffer = &freezeframe->capture_buffer;
@@ -611,11 +603,8 @@ init_meminit__destroy(
         }
 
         wl_buffer_destroy(st_output->capture.frame_ctx.scran_wl_buffer.wl_buffer);
-
-        if (g_state.options.freezeframe) {
-            wl_buffer_destroy(st_output->freezeframe.capture_buffer.scran_wl_buffer.wl_buffer);
-            wl_buffer_destroy(st_output->freezeframe.surface_buffer.scran_wl_buffer.wl_buffer);
-        }
+        wl_buffer_destroy(st_output->freezeframe.capture_buffer.scran_wl_buffer.wl_buffer);
+        wl_buffer_destroy(st_output->freezeframe.surface_buffer.scran_wl_buffer.wl_buffer);
     }
     wl_buffer_destroy(g_state.transparent_single_pixel_buffer.wl_buffer);
 

--- a/src/options.c
+++ b/src/options.c
@@ -434,8 +434,7 @@ static const char help_string[] =
     "         browser). Useful if you want to pipe scran's output to an application\n"
     "         that is waiting for scran to fully exit.\n"
     "         NOTE: This also disables notification interaction\n"
-    "  -z   freeze the display at startup\n"
-    "         Typing 'z' toggles and refreshes the freezeframe.\n"
+    "  -z   automatically freeze the display at startup\n"
     "  -s   slurp: send selection as geometry string to standard output\n"
     "         Replaces/disables image capture.\n"
     "         Format: '<x>,<y> <width>x<height>'\n"
@@ -478,7 +477,7 @@ scran_handle_args(int argc, char *const *argv)
         case 'A': g_state.options.disable_audio_capture                 = true;   break;
         case 'C': g_state.options.disable_cursor_capture                = true;   break;
         case 'B': g_state.options.no_keepalive                          = true;   break;
-        case 'z': g_state.options.freezeframe                           = true;   break;
+        case 'z': g_state.options.freezeframe_at_startup                           = true;   break;
         case 's': g_state.options.produce_slurp                         = true;   break;
         case 'U': g_state.options.hide_ui_level                         += 1;     break;
         case 'g':

--- a/src/options.c
+++ b/src/options.c
@@ -435,7 +435,7 @@ static const char help_string[] =
     "         that is waiting for scran to fully exit.\n"
     "         NOTE: This also disables notification interaction\n"
     "  -z   freeze the display at startup\n"
-    "         Typing 'z' or grabbing/releasing focus toggles hide/refresh.\n"
+    "         Typing 'z' toggles and refreshes the freezeframe.\n"
     "  -s   slurp: send selection as geometry string to standard output\n"
     "         Replaces/disables image capture.\n"
     "         Format: '<x>,<y> <width>x<height>'\n"

--- a/src/selection.c
+++ b/src/selection.c
@@ -267,11 +267,6 @@ start_grabbing_focus()
     DEBUG("Grabbing focus\n");
 
     FOR_EACH_OUTPUT(i, st_output) {
-        if (g_state.options.freezeframe) {
-            freezeframe_capture_refresh(st_output, start_grabbing_focus_for_output);
-            continue;
-        }
-
         start_grabbing_focus_for_output(st_output);
     }
 }

--- a/src/selection.c
+++ b/src/selection.c
@@ -300,10 +300,8 @@ stop_grabbing_focus()
 {
     DEBUG("Releasing focus\n");
 
-    if (g_state.options.freezeframe) {
-        FOR_EACH_OUTPUT(i, st_output) {
-            freezeframe_hide_surface(st_output);
-        }
+    FOR_EACH_OUTPUT(i, st_output) {
+        freezeframe_hide_surface(st_output);
     }
 
     const enum scran_ui_text focus_released_keymap_text = get_focus_released_keymap_text(scran_dbus_have_tray_icon());

--- a/src/ui.c
+++ b/src/ui.c
@@ -621,8 +621,7 @@ static const struct default_textline_values m_statusline_defaults[] = {
 static const struct default_textline_values m_keymap_defaults[] = {
     [SCRAN_UI_KEYMAP_ITEM_I_IMAGE]                  = { SCRAN_UI_TEXT_KEYMAP_IMAGE_DEFAULT,            SCRAN_UI_COLOR_DEFAULT },
     [SCRAN_UI_KEYMAP_ITEM_I_VIDEO]                  = { SCRAN_UI_TEXT_KEYMAP_VIDEO_DEFAULT,            SCRAN_UI_COLOR_DEFAULT },
-    // Freezeframe init code enables this.
-    [SCRAN_UI_KEYMAP_ITEM_I_FREEZEFRAME]            = { SCRAN_UI_TEXT_EMPTY,                           SCRAN_UI_COLOR_DEFAULT },
+    [SCRAN_UI_KEYMAP_ITEM_I_FREEZEFRAME]            = { SCRAN_UI_TEXT_KEYMAP_FREEZEFRAME_TURN_ON,      SCRAN_UI_COLOR_DEFAULT },
     [SCRAN_UI_KEYMAP_ITEM_I_FOCUS]                  = { SCRAN_UI_TEXT_KEYMAP_FOCUS_DEFAULT,            SCRAN_UI_COLOR_DEFAULT },
 };
 static const struct default_textline_values m_atlas_digits_defaults[] = {

--- a/src/ui.c
+++ b/src/ui.c
@@ -55,8 +55,8 @@ static const struct ui_string ui_texts[] = {
     [SCRAN_UI_TEXT_KEYMAP_FOCUS_RELEASED_TRAY]      = INIT_UI_STRING(u"[⇥] Click tray icon to retake focus."),
     [SCRAN_UI_TEXT_KEYMAP_FOCUS_RELEASED_HELP]      = INIT_UI_STRING(u"[⇥] Focus released. 'scran -h' for help."),
 
-    [SCRAN_UI_TEXT_KEYMAP_FREEZEFRAME_TURN_ON]      = INIT_UI_STRING(u"[Z] Freeze screen"),
-    [SCRAN_UI_TEXT_KEYMAP_FREEZEFRAME_TURN_OFF]     = INIT_UI_STRING(u"[Z] Unfreeze screen"),
+    [SCRAN_UI_TEXT_KEYMAP_FREEZEFRAME_TURN_ON]      = INIT_UI_STRING(u"[Z] Freeze screens"),
+    [SCRAN_UI_TEXT_KEYMAP_FREEZEFRAME_TURN_OFF]     = INIT_UI_STRING(u"[Z] Unfreeze screens"),
 
     // Placeholders for calculating metadata (currently just max pixel widths)
     // - actual text is dynamic for these.

--- a/src/util/state-util.c
+++ b/src/util/state-util.c
@@ -194,9 +194,7 @@ update_surface_scale_bufsize_viewport(
         DEBUG("    Selection surface disabled; deferring viewport update.\n");
     }
 
-    if (g_state.options.freezeframe) {
-        freezeframe_surface_update_scale_size_viewport(st_output);
-    }
+    freezeframe_surface_update_scale_size_viewport(st_output);
 }
 
 void


### PR DESCRIPTION
Make freezeframe always available in the UI (as a keymap).

- `scran -z` now just makes it pre-frozen at launch
- retaking focus (SIGUSR1) no longer re-freezes