### PR TITLE
Improve selection/capture size robustness

### DIFF
--- a/include/selection.h
+++ b/include/selection.h
@@ -7,6 +7,7 @@
 
 #include "state.h"
 #include "state-util.h"
+#include "util/blend2d.h"
 
 
 #define SCRAN_LAYER_SURFACE_KEYBOARD_INTERACTIVITY_FOCUSED   ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_EXCLUSIVE
@@ -53,6 +54,20 @@ static inline bool
 selection_is_none(struct scran_output_selectionContext *selection_ctx) {
     return selection_ctx->selection_state == SELECTION_NONE ||
            selection_ctx->selection_state == SELECTION_NONE_FREEZE_SIZE;
+}
+
+static inline BLBoxI
+selection_get_box_px(const struct scran_output_selectionContext *selection_ctx) {
+    assert(!blboxi_is_inverted(selection_ctx->box_px));
+    return selection_ctx->box_px;
+}
+
+static inline void
+selection_set_box_px(
+    struct scran_output_selectionContext *selection_ctx,
+    BLBoxI box_px
+) {
+    selection_ctx->box_px = blboxi_get_deinverted(box_px);
 }
 
 

--- a/include/state.h
+++ b/include/state.h
@@ -335,7 +335,7 @@ struct scran_output_selectionContext {
     //   physical pixels +/- 1 pixel (still with the buffer's transform!!).
     //   This seems to hold true at the moment on Sway, COSMIC and Hyprland,
     //   once all layer_surface::configure events have fired.
-    //   NOTE: Allowed to be inverted during resizing.
+    //   NOTE: Always deinverted. Update through selection_set_box_px().
     //   TODO: Make the coordinate space distinctions typed, in general?
     //           E.g. BLBoxISelection
     struct BLBoxI box_px;

--- a/include/state.h
+++ b/include/state.h
@@ -483,7 +483,7 @@ struct scran_options {
     bool capture_and_exit_after_selection_init;
     bool produce_slurp;                 // output slurp-style geometry string
     bool no_notifications;
-    bool have_custom_initial_selection; // output slurp-style geometry string
+    bool have_custom_initial_selection;
     enum scran_opt_hide_ui_level hide_ui_level;
     struct BLRectI custom_initial_selection_global_coordinates;
 };

--- a/src/capture.c
+++ b/src/capture.c
@@ -436,8 +436,7 @@ video_capture_start(struct scran_output *st_output)
     }
 
     // TODO: Assert box is within output dimensions
-    //       Assert box is not inverted
-    assert(!blboxi_is_empty(st_output->selection_ctx.box_px));
+    assert(!blboxi_is_empty(selection_get_box_px(&st_output->selection_ctx)));
 
     if (!init_ffmpeg(st_output)) {
         eprintf("Error: Failed to initialize ffmpeg libraries.\n");
@@ -505,7 +504,7 @@ start_fullscreen_capture(
     // need to save/restore the previous selection.
     assert(selection_is_none(&st_output->selection_ctx));
     BLBoxI fullscreen_selection = get_fullscreen_selection_box(st_output);
-    st_output->selection_ctx.box_px = fullscreen_selection;
+    selection_set_box_px(&st_output->selection_ctx, fullscreen_selection);
     capture_update_selection(st_output, fullscreen_selection);
 
     return true;
@@ -520,7 +519,10 @@ end_fullscreen_capture(
     // If !=SELECTION_NONE becomes possible in the future, then just do
     // capture_update_selection() when !=SELECTION_NONE.
     assert(selection_is_none(&st_output->selection_ctx));
-    st_output->selection_ctx.box_px = get_selection_surface_pre_selection_box(st_output);
+    selection_set_box_px(
+        &st_output->selection_ctx,
+        get_selection_surface_pre_selection_box(st_output)
+    );
     st_output->capture.frame_ctx.selection_ctx_box_px = (BLBoxI){0};
 
     st_output->capture.frame_ctx.fullscreen_capture = false;
@@ -688,9 +690,7 @@ print_slurp_string_selection(struct scran_output *st_output)
 {
     const double scale = st_output->selection_surface.surface.final_scale_factor_normalized;
     const struct scran_output_xdg_geometry geometry = st_output->xdg_geometry;
-    const struct BLBoxI box_px = st_output->selection_ctx.box_px;
-
-    assert(!blboxi_is_inverted(box_px));
+    const struct BLBoxI box_px = selection_get_box_px(&st_output->selection_ctx);
 
     const struct BLRectI rect_logical = {
         .x = round(  box_px.x0              / scale),

--- a/src/capture.c
+++ b/src/capture.c
@@ -133,7 +133,21 @@ video_capture_drain_encoder(
 // `selection_ctx_box_px` has `scran_output_selectionContext.box_px` coordinate space!
 void
 capture_update_selection(struct scran_output *st_output, BLBoxI selection_ctx_box_px) {
-    st_output->capture.frame_ctx.selection_ctx_box_px = selection_ctx_box_px;
+    struct capture_frame_context *frame_ctx = &st_output->capture.frame_ctx;
+
+    bool size_changed =
+           blboxi_width_abs_unsafe(frame_ctx->selection_ctx_box_px)  != blboxi_width_abs_unsafe(selection_ctx_box_px)
+        || blboxi_height_abs_unsafe(frame_ctx->selection_ctx_box_px) != blboxi_height_abs_unsafe(selection_ctx_box_px);
+
+    // Presentation feedback for an older selection-surface buffer can arrive
+    // after video capture has frozen the selection size.
+    // FIXME: Actually check if frozen here instead, but probably decouple
+    // selection's frozen state from selection_state first.
+    if (frame_ctx->capturing_video && size_changed) {
+        return;
+    }
+
+    frame_ctx->selection_ctx_box_px = selection_ctx_box_px;
 }
 
 struct ext_image_copy_capture_frame_v1 *

--- a/src/event-handlers/keyboard.c
+++ b/src/event-handlers/keyboard.c
@@ -87,14 +87,14 @@ shift_selection(
     int x_shift,
     int y_shift
 ) {
-    const BLBoxI shifted = blboxi_get_shifted(st_output->selection_ctx.box_px, x_shift, y_shift);
+    const BLBoxI shifted = blboxi_get_shifted(selection_get_box_px(&st_output->selection_ctx), x_shift, y_shift);
     const BLBoxI bounds = get_fullscreen_selection_box(st_output);
 
-    if (!blboxi_contains(bounds, blboxi_get_deinverted(shifted))) {
+    if (!blboxi_contains(bounds, shifted)) {
         return;
     }
 
-    st_output->selection_ctx.box_px = shifted;
+    selection_set_box_px(&st_output->selection_ctx, shifted);
     request_selection_surface_frame_callback(st_output);
 }
 

--- a/src/event-handlers/pointer.c
+++ b/src/event-handlers/pointer.c
@@ -79,24 +79,31 @@ handle_pointer_motion(
     int x_px = coords_px_.x;
     int y_px = coords_px_.y;
 
-    // TODO: Check if out of bounds
-    assert(!blboxi_is_inverted(selection_ctx->box_before_changes_px));
-
     switch (selection_ctx->selection_state) {
     case SELECTION_NONE:
     case SELECTION_NONE_FREEZE_SIZE:
         break;
     case SELECTION_INITIALIZING:
-        selection_ctx->box_px.x1 = x_px;
-        selection_ctx->box_px.y1 = y_px;
+        {
+            BLBoxI box_px = {
+                .x0 = selection_ctx->pointer_before_changes_x_px,
+                .y0 = selection_ctx->pointer_before_changes_y_px,
+                .x1 = x_px,
+                .y1 = y_px,
+            };
 
-        // TODO: Merge most of this logic with SELECTION_RESIZING?
+            // TODO: Merge most of this logic with SELECTION_RESIZING?
 
-        // XXX: Kinda redundant since we must also clamp on finishing selection
-        clamp_to_transformed_output_width(&selection_ctx->box_px.x1, st_output);
-        clamp_to_transformed_output_height(&selection_ctx->box_px.y1, st_output);
+            // XXX: Kinda redundant since we must also clamp on finishing selection
+            clamp_to_transformed_output_width(&box_px.x1, st_output);
+            clamp_to_transformed_output_height(&box_px.y1, st_output);
+            selection_set_box_px(selection_ctx, box_px);
+        }
 
-        scran_ui_statusline_set_selection_size(&st_output->selection_surface.ui_ctx.ui_statusline, blboxi_to_blrecti(selection_ctx->box_px));
+        scran_ui_statusline_set_selection_size(
+            &st_output->selection_surface.ui_ctx.ui_statusline,
+            blboxi_to_blrecti(selection_get_box_px(selection_ctx))
+        );
 
         request_selection_surface_frame_callback(st_output);
         break;
@@ -118,7 +125,6 @@ handle_pointer_motion(
             };
 
             // The rebase should have been initiated with a valid box.
-            assert(!blboxi_is_inverted(box_before_rebase));
             assert(box_before_rebase.x0 >= 0 && box_before_rebase.x1 <= get_transformed_output_width(st_output));
             assert(box_before_rebase.y0 >= 0 && box_before_rebase.y1 <= get_transformed_output_height(st_output));
 
@@ -139,7 +145,7 @@ handle_pointer_motion(
                 new_box.y1 = get_transformed_output_height(st_output);
             }
 
-            selection_ctx->box_px = new_box;
+            selection_set_box_px(selection_ctx, new_box);
         }
         request_selection_surface_frame_callback(st_output);
         break;
@@ -149,36 +155,40 @@ handle_pointer_motion(
             const int y_diff_px = y_px - selection_ctx->pointer_before_changes_y_px;
             const BLBoxI box_before_resize = selection_ctx->box_before_changes_px;
 
+            BLBoxI resized_box = box_before_resize;
+
             switch (selection_ctx->selection_resize_direction) {
             case SELECTION_RESIZE_NONE:
                 break;
             case SELECTION_RESIZE_TOP_LEFT:
-                selection_ctx->box_px.x0 = box_before_resize.x0 + x_diff_px;
-                selection_ctx->box_px.y0 = box_before_resize.y0 + y_diff_px;
-                clamp_to_transformed_output_width(&selection_ctx->box_px.x0, st_output);
-                clamp_to_transformed_output_height(&selection_ctx->box_px.y0, st_output);
+                resized_box.x0 += x_diff_px;
+                resized_box.y0 += y_diff_px;
+                clamp_to_transformed_output_width(&resized_box.x0, st_output);
+                clamp_to_transformed_output_height(&resized_box.y0, st_output);
                 break;
             case SELECTION_RESIZE_TOP_RIGHT:
-                selection_ctx->box_px.x1 = box_before_resize.x1 + x_diff_px;
-                selection_ctx->box_px.y0 = box_before_resize.y0 + y_diff_px;
-                clamp_to_transformed_output_width(&selection_ctx->box_px.x1, st_output);
-                clamp_to_transformed_output_height(&selection_ctx->box_px.y0, st_output);
+                resized_box.x1 += x_diff_px;
+                resized_box.y0 += y_diff_px;
+                clamp_to_transformed_output_width(&resized_box.x1, st_output);
+                clamp_to_transformed_output_height(&resized_box.y0, st_output);
                 break;
             case SELECTION_RESIZE_BOTTOM_LEFT:
-                selection_ctx->box_px.x0 = box_before_resize.x0 + x_diff_px;
-                selection_ctx->box_px.y1 = box_before_resize.y1 + y_diff_px;
-                clamp_to_transformed_output_width(&selection_ctx->box_px.x0, st_output);
-                clamp_to_transformed_output_height(&selection_ctx->box_px.y1, st_output);
+                resized_box.x0 += x_diff_px;
+                resized_box.y1 += y_diff_px;
+                clamp_to_transformed_output_width(&resized_box.x0, st_output);
+                clamp_to_transformed_output_height(&resized_box.y1, st_output);
                 break;
             case SELECTION_RESIZE_BOTTOM_RIGHT:
-                selection_ctx->box_px.x1 = box_before_resize.x1 + x_diff_px;
-                selection_ctx->box_px.y1 = box_before_resize.y1 + y_diff_px;
-                clamp_to_transformed_output_width(&selection_ctx->box_px.x1, st_output);
-                clamp_to_transformed_output_height(&selection_ctx->box_px.y1, st_output);
+                resized_box.x1 += x_diff_px;
+                resized_box.y1 += y_diff_px;
+                clamp_to_transformed_output_width(&resized_box.x1, st_output);
+                clamp_to_transformed_output_height(&resized_box.y1, st_output);
                 break;
             }
+
+            selection_set_box_px(selection_ctx, resized_box);
         }
-        scran_ui_statusline_set_selection_size(&st_output->selection_surface.ui_ctx.ui_statusline, blboxi_to_blrecti(selection_ctx->box_px));
+        scran_ui_statusline_set_selection_size(&st_output->selection_surface.ui_ctx.ui_statusline, blboxi_to_blrecti(selection_get_box_px(selection_ctx)));
         request_selection_surface_frame_callback(st_output);
         break;
     }
@@ -266,7 +276,9 @@ handle_pointer_button(
                 .x1 = x_px,
                 .y1 = y_px,
             };
-            selection_ctx->box_px = initial_selection_area;
+            selection_set_box_px(selection_ctx, initial_selection_area);
+            selection_ctx->pointer_before_changes_x_px = x_px;
+            selection_ctx->pointer_before_changes_y_px = y_px;
             selection_ctx->selection_state = SELECTION_INITIALIZING;
 
             // TODO: Create set_selection_initializing()/set_selection_stage(),
@@ -282,15 +294,21 @@ handle_pointer_button(
 
             break;
         case SELECTION_INITIALIZING:
-            selection_ctx->box_px.x1 = x_px;
-            selection_ctx->box_px.y1 = y_px;
+            {
+                BLBoxI box_px = {
+                    .x0 = selection_ctx->pointer_before_changes_x_px,
+                    .y0 = selection_ctx->pointer_before_changes_y_px,
+                    .x1 = x_px,
+                    .y1 = y_px,
+                };
 
-            blboxi_deinvert(&selection_ctx->box_px);
+                clamp_to_transformed_output_width(&box_px.x0, st_output);
+                clamp_to_transformed_output_height(&box_px.y0, st_output);
+                clamp_to_transformed_output_width(&box_px.x1, st_output);
+                clamp_to_transformed_output_height(&box_px.y1, st_output);
 
-            clamp_to_transformed_output_width(&selection_ctx->box_px.x0, st_output);
-            clamp_to_transformed_output_height(&selection_ctx->box_px.y0, st_output);
-            clamp_to_transformed_output_width(&selection_ctx->box_px.x1, st_output);
-            clamp_to_transformed_output_height(&selection_ctx->box_px.y1, st_output);
+                selection_set_box_px(selection_ctx, box_px);
+            }
 
             set_selection_initialized(st_output);
             assert(selection_ctx->selection_state == SELECTION_COMPLETE);
@@ -302,7 +320,7 @@ handle_pointer_button(
                                              ? SELECTION_REBASING : SELECTION_REBASING_FREEZE_SIZE;
             selection_ctx->pointer_before_changes_x_px = x_px;
             selection_ctx->pointer_before_changes_y_px = y_px;
-            selection_ctx->box_before_changes_px = selection_ctx->box_px;
+            selection_ctx->box_before_changes_px = selection_get_box_px(selection_ctx);
             break;
         case SELECTION_REBASING:
             selection_ctx->selection_state = SELECTION_COMPLETE;
@@ -318,7 +336,7 @@ handle_pointer_button(
         switch(selection_ctx->selection_state) {
         case SELECTION_COMPLETE:
             selection_ctx->selection_state = SELECTION_RESIZING;
-            selection_ctx->box_before_changes_px = selection_ctx->box_px;
+            selection_ctx->box_before_changes_px = selection_get_box_px(selection_ctx);
             selection_ctx->pointer_before_changes_x_px = x_px;
             selection_ctx->pointer_before_changes_y_px = y_px;
 
@@ -344,8 +362,6 @@ handle_pointer_button(
         case SELECTION_RESIZING:
             selection_ctx->selection_state = SELECTION_COMPLETE;
             selection_ctx->selection_resize_direction = SELECTION_RESIZE_NONE;
-
-            blboxi_deinvert(&selection_ctx->box_px);
             break;
         default:
             // Shunt back to a safe state to prevent state inversions or other

--- a/src/event-handlers/surface/selection.c
+++ b/src/event-handlers/surface/selection.c
@@ -8,8 +8,8 @@
 #include "state-util.h"
 #include "state.h"
 #include "event-handlers.h"
-#include "util/blend2d.h"
 #include "selection-surface.h"
+#include "selection.h"
 #include "capture.h"
 #include "print.h"
 
@@ -59,7 +59,7 @@ selection_surface_frame_callback_handler(
 
     // This is the capture area that the rest of this function is assuming will
     // be in use for the frame in which this selection area is presented.
-    const struct BLBoxI capture_area = blboxi_get_deinverted(st_output->selection_ctx.box_px);
+    const struct BLBoxI capture_area = selection_get_box_px(&st_output->selection_ctx);
     assert(capture_area.x1 <= get_transformed_output_width(st_output));
     assert(capture_area.y1 <= get_transformed_output_height(st_output));
 
@@ -109,4 +109,3 @@ selection_surface_frame_callback_handler(
 struct wl_callback_listener selection_surface_frame_callback_listener = {
     .done = selection_surface_frame_callback_handler
 };
-

--- a/src/selection-surface.c
+++ b/src/selection-surface.c
@@ -539,7 +539,7 @@ init_selection_surface_content(
 
     if (no_initial_selection) {
         initial_box = get_selection_surface_pre_selection_box(st_output);
-        st_output->selection_ctx.box_px = initial_box;
+        selection_set_box_px(&st_output->selection_ctx, initial_box);
 
         // Set fullscreen selection size.
         // XXX TODO: Make this responsibility less disjointed
@@ -551,7 +551,7 @@ init_selection_surface_content(
         set_selection_surface_theme(st_output, SURFACE_THEME_PRE_SELECTION);
     } else {
         // This must be set prior to set_selection_initialized()
-        st_output->selection_ctx.box_px = initial_box;
+        selection_set_box_px(&st_output->selection_ctx, initial_box);
         // These are usually called at "runtime"/main-loop-time, so call these
         // AFTER init_postmem__selection(), to ensure all relevant runtime
         // state has been set up.

--- a/src/selection.c
+++ b/src/selection.c
@@ -64,8 +64,6 @@ set_selection_initialized(struct scran_output *st_output)
     assert(st_output->selection_ctx.selection_state == SELECTION_INITIALIZING
            || (g_state.options.have_custom_initial_selection && st_output->selection_ctx.selection_state == SELECTION_NONE));
 
-    // TODO: Not sure if we should deinvert in here or let the caller decide
-
     st_output->selection_ctx.selection_state = SELECTION_COMPLETE;
 
     // Reset button, since this function could have interrupted an ongoing
@@ -75,7 +73,7 @@ set_selection_initialized(struct scran_output *st_output)
     // Make sure this is initialized immediately, to not be dependent on
     // surface::frame being done, for example when using 'scran -eg'.
     //     TODO: Would be better to de-couple this somehow.
-    capture_update_selection(st_output, st_output->selection_ctx.box_px);
+    capture_update_selection(st_output, selection_get_box_px(&st_output->selection_ctx));
 
     if (g_state.options.capture_and_exit_after_selection_init) {
         DEBUG("STARTING AUTOMATIC IMAGE CAPTURE\n");

--- a/src/util/state-util.c
+++ b/src/util/state-util.c
@@ -8,6 +8,7 @@
 #include "freezeframe.h"
 #include "print.h"
 #include "selection-surface.h"
+#include "selection.h"
 
 
 void
@@ -202,7 +203,10 @@ do_scale_updates(struct scran_output *st_output)
     reinit_scran_ui(&st_output->selection_surface.ui_ctx, st_output->selection_surface.surface.final_scale_factor_normalized);
     // XXX NOTE: Do not update if SELECTION_NONE_FREEZE_SIZE, since there might be an active capture.
     if (st_output->selection_ctx.selection_state == SELECTION_NONE) {
-        st_output->selection_ctx.box_px = get_selection_surface_pre_selection_box(st_output);
+        selection_set_box_px(
+            &st_output->selection_ctx,
+            get_selection_surface_pre_selection_box(st_output)
+        );
     }
     set_force_redraw_selection_surface_buffers(st_output);
     request_selection_surface_frame_callback(st_output);


### PR DESCRIPTION
- Make sure selection-box is never inverted
- Extra guard against capture-size updates during video capture, since in-flight presentation-feedback callbacks can circumvent the frozen selection size