### PR TITLE
Add editlist

### DIFF
--- a/src/capture/write/video.c
+++ b/src/capture/write/video.c
@@ -259,6 +259,12 @@ init_ffmpeg(struct scran_output *st_output, const BLPointI dimensions)
     av_dict_set(&format_opts, "movflags", "frag_keyframe+empty_moov+default_base_moof", 0);
 #else
     av_dict_set(&format_opts, "movflags", "hybrid_fragmented", 0);
+    // Our mp4 muxer may shift the PTS/DTS timelines forwards to ensure that the
+    // first DTS is non-negative. Some players/programs need an explicit
+    // "editlist" in the moov, which specifies the timestamp at which the actual
+    // playback is supposed to start. For example Adobe Premiere refuses to open
+    // the file otherwise.
+    av_dict_set(&format_opts, "use_editlist", "1", 0);
 #endif /* LIBAVFORMAT_VERSION_INT */
     int format_ret = avformat_write_header(ffmpeg_ctx->av_format_ctx, &format_opts);
     av_dict_free(&format_opts);


### PR DESCRIPTION
Adobe Premiere was reportedly refusing to open scran videos without this.

See comment in commit for details.